### PR TITLE
Use sub-interface

### DIFF
--- a/pkg/controller/agent/nodenetwork/controller.go
+++ b/pkg/controller/agent/nodenetwork/controller.go
@@ -173,10 +173,13 @@ func (h Handler) repealVlan(nn *networkv1.NodeNetwork) error {
 	}
 
 	configuredNIC := v.NIC().Name()
-	if configuredNIC != "" && configuredNIC != nn.Spec.NIC {
-		if err := v.Teardown(); err != nil {
-			return fmt.Errorf("tear down vlan failed, error: %s, nic: %s", err.Error(), configuredNIC)
-		}
+	parentNIC := v.ParentNIC().Name()
+	if configuredNIC == "" || configuredNIC == nn.Spec.NIC || parentNIC == nn.Spec.NIC {
+		return nil
+	}
+
+	if err := v.Teardown(); err != nil {
+		return fmt.Errorf("tear down vlan failed, error: %s, nic: %s", err.Error(), configuredNIC)
 	}
 
 	return nil

--- a/pkg/network/iface/link.go
+++ b/pkg/network/iface/link.go
@@ -23,6 +23,7 @@ const (
 	TypeLoopback = "loopback"
 	TypeDevice   = "device"
 	TypeBond     = "bond"
+	TypeMacVlan  = "macvlan"
 )
 
 type Link struct {
@@ -234,6 +235,26 @@ func (l *Link) DeleteRoutes() error {
 	}
 
 	return nil
+}
+
+// GetSubLink to get or create a macvlan interface
+func (l *Link) GetSubLink(name string) (*Link, error) {
+	macvlan := &netlink.Macvlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        name,
+			ParentIndex: l.LinkAttrs().Index,
+		},
+		Mode: netlink.MACVLAN_MODE_DEFAULT,
+	}
+	if err := netlink.LinkAdd(macvlan); err != nil && err != syscall.EEXIST {
+		return nil, err
+	}
+
+	if err := netlink.LinkSetUp(macvlan); err != nil {
+		return nil, err
+	}
+
+	return GetLinkByName(name)
 }
 
 func (l *Link) Index() int {


### PR DESCRIPTION
To use a macvlan interface rather than the NIC itself if it's used by the management network.

issue: https://github.com/harvester/harvester/issues/980