### PR TITLE
No need to wait down signal after setting no master

### DIFF
--- a/pkg/controller/agent/nodenetwork/controller.go
+++ b/pkg/controller/agent/nodenetwork/controller.go
@@ -323,7 +323,7 @@ func (h Handler) getNetworkInterfaces() ([]networkv1.NetworkInterface, error) {
 	if err == nil {
 		vlanNiIndex = v.NIC().Index()
 	} else {
-		klog.Errorf("Can not get VLAN, error: %v", err)
+		klog.Infof("couldn't get VLAN, reason: %v", err)
 	}
 
 	networkInterfaces := make([]networkv1.NetworkInterface, 0)


### PR DESCRIPTION
The network interface will not be down after setting nomaster from the bridge in the new harvester-os.

Related issue: 
https://github.com/harvester/harvester/issues/1464
https://github.com/harvester/harvester/issues/1529