### PR TITLE
Ignore default PVID

### DIFF
--- a/pkg/network/iface/link.go
+++ b/pkg/network/iface/link.go
@@ -24,6 +24,8 @@ const (
 
 	tableFilter  = "filter"
 	chainForward = "FORWARD"
+
+	defaultPVID = uint16(1)
 )
 
 type Link struct {
@@ -79,6 +81,11 @@ func GetLinkByIndex(index int) (*Link, error) {
 // AddBridgeVlan adds a new vlan filter entry
 // Equivalent to: `bridge vlan add dev DEV vid VID master`
 func (l *Link) AddBridgeVlan(vid uint16) error {
+	// The command to configure PVID is not `bridge vlan add dev DEV vid VID master`
+	if vid == defaultPVID {
+		return nil
+	}
+
 	if err := netlink.BridgeVlanAdd(l.link, vid, false, false, false, true); err != nil {
 		return fmt.Errorf("add iface vlan failed, error: %v, link: %s, vid: %d", err, l.Name(), vid)
 	}
@@ -89,6 +96,10 @@ func (l *Link) AddBridgeVlan(vid uint16) error {
 // DelBridgeVlan adds a new vlan filter entry
 // Equivalent to: `bridge vlan del dev DEV vid VID master`
 func (l *Link) DelBridgeVlan(vid uint16) error {
+	if vid == defaultPVID {
+		return nil
+	}
+
 	if err := netlink.BridgeVlanDel(l.link, vid, false, false, false, true); err != nil {
 		return fmt.Errorf("delete iface vlan failed, error: %v, link: %s, vid: %d", err, l.Name(), vid)
 	}

--- a/pkg/network/vlan/vlan.go
+++ b/pkg/network/vlan/vlan.go
@@ -24,7 +24,6 @@ type Vlan struct {
 
 const (
 	BridgeName = "harvester-br0"
-	PVID       = 1
 )
 
 func (v *Vlan) Type() string {
@@ -179,9 +178,6 @@ func (v *Vlan) AddLocalArea(id int, cidr string) error {
 	if v.nic == nil {
 		return fmt.Errorf("physical nic vlan network")
 	}
-	if id == PVID {
-		return nil
-	}
 
 	if err := v.nic.AddBridgeVlan(uint16(id)); err != nil {
 		return fmt.Errorf("add bridge vlan %d failed, error: %w", id, err)
@@ -205,9 +201,6 @@ func (v *Vlan) AddLocalArea(id int, cidr string) error {
 func (v *Vlan) RemoveLocalArea(id int, cidr string) error {
 	if v.nic == nil {
 		return fmt.Errorf("physical nic vlan network")
-	}
-	if id == PVID {
-		return nil
 	}
 
 	if err := v.nic.DelBridgeVlan(uint16(id)); err != nil {


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/1669

The command to configure PVID is different from other VIDs. Assume we
want to configure PVID as 1 and add VID 10 for harvester-mgmt, the commands are as followings.
- Configure PVID 1
  `bridge vlan add vid 1 dev harvester-mgmt pvid untagged master`
- Add VID 10
  `bridge vlan add vid 10 dev harvester-mgmt master`
The default PVID is 1, so we ignore it.