### PR TITLE
Migrate base image to BCI image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine:3.12
-# ebtables v2.0.10-4
-# iptables v1.6.2
-# The default repository of alpine 3.12 only contains iptables v1.8.4 which includes the ebtables 1.8.4, but we want the version more that 2.0.10-4.
-RUN echo -e 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' > /etc/apk/repositories && apk update && apk add --no-cache ebtables iptables
+FROM registry.suse.com/bci/bci-base:15.3
+RUN zypper -n rm container-suseconnect && \
+    zypper install -y iptables=1.8.7 && \
+    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 COPY bin/harvester-network-controller /usr/bin/
 CMD ["harvester-network-controller"]

--- a/package/Dockerfile.helper
+++ b/package/Dockerfile.helper
@@ -1,3 +1,3 @@
-FROM alpine:3.12
+FROM registry.suse.com/bci/bci-minimal:15.3
 COPY bin/harvester-network-helper /usr/bin/
 CMD ["harvester-network-helper"]


### PR DESCRIPTION
We won't install ebtables in the new image.
The harvester-br0 only inherits the IP address and routes of the
harvester-mgmt network interface. Meanwhile, the IP address of
the harvester-mgmt could not be changed. Therefore, it's not necessary
to allow the DHCP package to pass to the VLAN interface anymore.

Related issue: https://github.com/harvester/harvester/issues/1868