### PR TITLE
Support updating VM networks and changing cluster network migration of vlanconfigs

### DIFF
--- a/pkg/controller/agent/nad/controller.go
+++ b/pkg/controller/agent/nad/controller.go
@@ -147,12 +147,12 @@ func (h Handler) removeOutdatedLocalArea(nad *nadv1.NetworkAttachmentDefinition)
 	if clusternetwork == "" {
 		clusternetwork = nad.Labels[utils.KeyClusterNetworkLabel]
 	}
-	vlanIdStr := nad.Labels[utils.KeyLastVlanLabel]
-	if vlanIdStr == "" {
-		vlanIdStr = nad.Labels[utils.KeyVlanLabel]
+	vlanIDStr := nad.Labels[utils.KeyLastVlanLabel]
+	if vlanIDStr == "" {
+		vlanIDStr = nad.Labels[utils.KeyVlanLabel]
 	}
 
-	localArea, err := GetLocalArea(vlanIdStr, nad.Annotations[utils.KeyNetworkRoute])
+	localArea, err := GetLocalArea(vlanIDStr, nad.Annotations[utils.KeyNetworkRoute])
 	if err != nil {
 		return nil, fmt.Errorf("failed to get local area from nad %s/%s, error: %w", nad.Namespace, nad.Name, err)
 	}
@@ -168,10 +168,10 @@ func (h Handler) removeOutdatedLocalArea(nad *nadv1.NetworkAttachmentDefinition)
 	return nadCopy, nil
 }
 
-func GetLocalArea(vlanIdStr, routeConf string) (*vlan.LocalArea, error) {
-	vlanID, err := strconv.Atoi(vlanIdStr)
+func GetLocalArea(vlanIDStr, routeConf string) (*vlan.LocalArea, error) {
+	vlanID, err := strconv.Atoi(vlanIDStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid vlan id %s", vlanIdStr)
+		return nil, fmt.Errorf("invalid vlan id %s", vlanIDStr)
 	}
 
 	layer3NetworkConf := &utils.Layer3NetworkConf{}

--- a/pkg/controller/agent/vlanconfig/controller.go
+++ b/pkg/controller/agent/vlanconfig/controller.go
@@ -84,7 +84,7 @@ func (h Handler) OnChange(key string, vc *networkv1.VlanConfig) (*networkv1.Vlan
 		return nil, err
 	}
 
-	if !isMatched && vs != nil || isMatched && vs != nil && !matchClusterNetwork(vc, vs) {
+	if (!isMatched && vs != nil) || (isMatched && vs != nil && !matchClusterNetwork(vc, vs)) {
 		if err := h.removeVLAN(vs); err != nil {
 			return nil, err
 		}

--- a/pkg/controller/manager/clusternetwork/controller.go
+++ b/pkg/controller/manager/clusternetwork/controller.go
@@ -131,6 +131,7 @@ func (h Handler) deleteLinkMonitor(name string) error {
 
 func (h Handler) setNadReadyLabel(cn *networkv1.ClusterNetwork) error {
 	isReady := utils.ValueFalse
+	// Set all net-attach-defs under the cluster network to be deleted as unready
 	if cn.DeletionTimestamp != nil && networkv1.Ready.IsTrue(cn.Status) {
 		isReady = utils.ValueTrue
 	}

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -55,7 +55,7 @@ func (n *NetHelper) RecordToNad(selectedNetwork *nadv1.NetworkSelectionElement, 
 		return err
 	}
 
-	nadCopy.Annotations[utils.KeyNetworkConf] = confStr
+	nadCopy.Annotations[utils.KeyNetworkRoute] = confStr
 
 	_, err = n.nadClient.Update(nadCopy)
 	return err

--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -3,14 +3,20 @@ package utils
 import "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io"
 
 const (
-	KeyNetworkConf         = network.GroupName + "/route"
-	KeyVlanLabel           = network.GroupName + "/vlan-id"
+	KeyVlanLabel = network.GroupName + "/vlan-id"
+	// KeyLastVlanLabel is used to record the last VLAN id to support changing the VLAN id of the VLAN networks
+	KeyLastVlanLabel       = network.GroupName + "/last-vlan-id"
 	KeyVlanConfigLabel     = network.GroupName + "/vlanconfig"
 	KeyClusterNetworkLabel = network.GroupName + "/clusternetwork"
-	KeyNodeLabel           = network.GroupName + "/node"
-	KeyNetworkType         = network.GroupName + "/type"
+	// KeyLastClusterNetworkLabel is used to record the last cluster network to support changing the cluster network of NADs
+	KeyLastClusterNetworkLabel = network.GroupName + "/last-clusternetwork"
+	KeyNodeLabel               = network.GroupName + "/node"
+	KeyNetworkType             = network.GroupName + "/type"
+	KeyNetworkReady            = network.GroupName + "/ready"
+	KeyNetworkRoute            = network.GroupName + "/route"
 
 	KeyMatchedNodes = network.GroupName + "/matched-nodes"
 
-	ValueTrue = "true"
+	ValueTrue  = "true"
+	ValueFalse = "false"
 )

--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -12,6 +12,7 @@ const (
 	KeyLastClusterNetworkLabel = network.GroupName + "/last-clusternetwork"
 	KeyNodeLabel               = network.GroupName + "/node"
 	KeyNetworkType             = network.GroupName + "/type"
+	KeyLastNetworkType         = network.GroupName + "/last-type"
 	KeyNetworkReady            = network.GroupName + "/ready"
 	KeyNetworkRoute            = network.GroupName + "/route"
 

--- a/pkg/utils/nad.go
+++ b/pkg/utils/nad.go
@@ -25,6 +25,13 @@ const (
 	Manual Mode = "manual"
 )
 
+type NetworkType string
+
+const (
+	L2VlanNetwork   NetworkType = "L2VlanNetwork"
+	UntaggedNetwork NetworkType = "UntaggedNetwork"
+)
+
 type NadSelectedNetworks []nadv1.NetworkSelectionElement
 
 type Layer3NetworkConf struct {
@@ -33,6 +40,7 @@ type Layer3NetworkConf struct {
 	Gateway      string       `json:"gateway,omitempty"`
 	ServerIPAddr string       `json:"serverIPAddr,omitempty"`
 	Connectivity Connectivity `json:"connectivity,omitempty"`
+	Outdated     bool         `json:"outdated,omitempty"`
 }
 
 func NewLayer3NetworkConf(conf string) (*Layer3NetworkConf, error) {
@@ -96,7 +104,7 @@ type NetConf struct {
 	Vlan         int    `json:"vlan"`
 }
 
-func IsVlanNAD(nad *nadv1.NetworkAttachmentDefinition) bool {
+func IsVlanNad(nad *nadv1.NetworkAttachmentDefinition) bool {
 	if nad == nil || nad.Spec.Config == "" || nad.Labels == nil || nad.Labels[KeyNetworkType] == "" ||
 		nad.Labels[KeyClusterNetworkLabel] == "" || nad.Labels[KeyVlanLabel] == "" {
 		return false

--- a/pkg/utils/name.go
+++ b/pkg/utils/name.go
@@ -14,9 +14,9 @@ func Name(prefix string, s ...string) string {
 	digest := crc32.ChecksumIEEE([]byte(name))
 	suffix := fmt.Sprintf("%08x", digest)
 	// The name contains no more than 63 characters
-	maxLengthOfName := maxLengthOfName - 1 - len(suffix)
-	if len(name) > maxLengthOfName {
-		name = name[:maxLengthOfName]
+	maxLength := maxLengthOfName - 1 - len(suffix)
+	if len(name) > maxLength {
+		name = name[:maxLength]
 	}
 
 	return name + "-" + suffix

--- a/pkg/utils/vmi.go
+++ b/pkg/utils/vmi.go
@@ -19,7 +19,6 @@ func (v *VmiGetter) WhoUseNad(nad *nadv1.NetworkAttachmentDefinition, nodesFilte
 	// ref: https://github.com/kubevirt/client-go/blob/148fa0d1c7e83b7a56606a7ca92394ba6768c9ac/api/v1/schema.go#L1436-L1439
 	networkName := fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
 	vmis, err := v.VmiCache.GetByIndex(indexeres.VMByNetworkIndex, networkName)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/vmi.go
+++ b/pkg/utils/vmi.go
@@ -39,12 +39,13 @@ func (v *VmiGetter) WhoUseNad(nad *nadv1.NetworkAttachmentDefinition, nodesFilte
 		return vmis, nil
 	}
 
+	afterFilter := make([]*kubevirtv1.VirtualMachineInstance, 0, len(vmis))
 	// filter vmis whose status.nodeName is not in the nodes map
-	for i, vmi := range vmis {
-		if !nodesFilter[vmi.Status.NodeName] {
-			vmis = append(vmis[:i], vmis[i+1:]...)
+	for _, vmi := range vmis {
+		if nodesFilter[vmi.Status.NodeName] {
+			afterFilter = append(afterFilter, vmi)
 		}
 	}
 
-	return vmis, nil
+	return afterFilter, nil
 }

--- a/pkg/utils/vmi.go
+++ b/pkg/utils/vmi.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"fmt"
+
+	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
+	"github.com/harvester/harvester/pkg/indexeres"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+type VmiGetter struct {
+	VmiCache ctlkubevirtv1.VirtualMachineInstanceCache
+}
+
+// WhoUseNad requires adding network indexer to the vmi cache before invoking it
+func (v *VmiGetter) WhoUseNad(nad *nadv1.NetworkAttachmentDefinition, nodesFilter map[string]bool) ([]*kubevirtv1.VirtualMachineInstance, error) {
+	// multus network name can be <networkName> or <namespace>/<networkName>
+	// ref: https://github.com/kubevirt/client-go/blob/148fa0d1c7e83b7a56606a7ca92394ba6768c9ac/api/v1/schema.go#L1436-L1439
+	networkName := fmt.Sprintf("%s/%s", nad.Namespace, nad.Name)
+	vmis, err := v.VmiCache.GetByIndex(indexeres.VMByNetworkIndex, networkName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	vmisTmp, err := v.VmiCache.GetByIndex(indexeres.VMByNetworkIndex, nad.Name)
+	if err != nil {
+		return nil, err
+	}
+	for _, vmi := range vmisTmp {
+		if vmi.Namespace != nad.Namespace {
+			continue
+		}
+		vmis = append(vmis, vmi)
+	}
+
+	if len(nodesFilter) == 0 {
+		return vmis, nil
+	}
+
+	// filter vmis whose status.nodeName is not in the nodes map
+	for i, vmi := range vmis {
+		if !nodesFilter[vmi.Status.NodeName] {
+			vmis = append(vmis[:i], vmis[i+1:]...)
+		}
+	}
+
+	return vmis, nil
+}

--- a/pkg/webhook/nad/mutator.go
+++ b/pkg/webhook/nad/mutator.go
@@ -1,0 +1,158 @@
+package nad
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/harvester/webhook/pkg/types"
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+
+	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
+	ctlnetworkv1 "github.com/harvester/harvester-network-controller/pkg/generated/controllers/network.harvesterhci.io/v1beta1"
+	"github.com/harvester/harvester-network-controller/pkg/network/iface"
+	"github.com/harvester/harvester-network-controller/pkg/utils"
+)
+
+var _ types.Mutator = &NadMutator{}
+
+type NadMutator struct {
+	types.DefaultMutator
+	cnCache ctlnetworkv1.ClusterNetworkCache
+}
+
+func NewNadMutator(cnCache ctlnetworkv1.ClusterNetworkCache) *NadMutator {
+	return &NadMutator{
+		cnCache: cnCache,
+	}
+}
+
+func (n *NadMutator) Update(_ *types.Request, oldObj, newObj runtime.Object) (types.Patch, error) {
+	oldNad := oldObj.(*cniv1.NetworkAttachmentDefinition)
+	newNad := newObj.(*cniv1.NetworkAttachmentDefinition)
+
+	if newNad.DeletionTimestamp != nil {
+		return nil, nil
+	}
+
+	if oldNad.Spec.Config == newNad.Spec.Config {
+		return nil, nil
+	}
+
+	oldNetconf, newNetconf := &utils.NetConf{}, &utils.NetConf{}
+	if err := json.Unmarshal([]byte(oldNad.Spec.Config), oldNetconf); err != nil {
+		return nil, fmt.Errorf(updateErr, oldNad.Namespace, oldNad.Name, err)
+	}
+	if err := json.Unmarshal([]byte(newNad.Spec.Config), newNetconf); err != nil {
+		return nil, fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
+	}
+
+	patch, err := n.ensureLabels(newNad, oldNetconf, newNetconf)
+	if err != nil {
+		return nil, fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
+	}
+
+	annotationPatch, err := tagRouteOutdated(newNad, oldNetconf, newNetconf)
+	if err != nil {
+		return nil, fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
+	}
+
+	return append(patch, annotationPatch...), nil
+}
+
+func (n *NadMutator) Resource() types.Resource {
+	return types.Resource{
+		Names:      []string{"network-attachment-definitions"},
+		Scope:      admissionregv1.NamespacedScope,
+		APIGroup:   cniv1.SchemeGroupVersion.Group,
+		APIVersion: cniv1.SchemeGroupVersion.Version,
+		ObjectType: &cniv1.NetworkAttachmentDefinition{},
+		OperationTypes: []admissionregv1.OperationType{
+			admissionregv1.Update,
+		},
+	}
+}
+
+func (n *NadMutator) ensureLabels(nad *cniv1.NetworkAttachmentDefinition, oldConf, newConf *utils.NetConf) (types.Patch, error) {
+	labels := nad.Labels
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	if newConf.Vlan != 0 {
+		labels[utils.KeyNetworkType] = string(utils.L2VlanNetwork)
+		labels[utils.KeyVlanLabel] = strconv.Itoa(newConf.Vlan)
+	} else {
+		labels[utils.KeyNetworkType] = string(utils.UntaggedNetwork)
+		delete(labels, utils.KeyVlanLabel)
+	}
+	if oldConf.Vlan != 0 && oldConf.Vlan != newConf.Vlan {
+		labels[utils.KeyLastVlanLabel] = strconv.Itoa(oldConf.Vlan)
+	}
+
+	cnName := newConf.BrName[:len(newConf.BrName)-len(iface.BridgeSuffix)]
+	labels[utils.KeyClusterNetworkLabel] = cnName
+	if oldConf.BrName != newConf.BrName {
+		labels[utils.KeyLastClusterNetworkLabel] = oldConf.BrName[:len(oldConf.BrName)-len(iface.BridgeSuffix)]
+	}
+	if cn, err := n.cnCache.Get(cnName); err != nil {
+		return nil, err
+	} else if networkv1.Ready.IsTrue(cn.Status) {
+		labels[utils.KeyNetworkReady] = utils.ValueTrue
+	} else {
+		labels[utils.KeyNetworkReady] = utils.ValueFalse
+	}
+
+	return types.Patch{
+		types.PatchOp{
+			Op:    types.PatchOpReplace,
+			Path:  "/metadata/labels",
+			Value: labels,
+		}}, nil
+}
+
+func tagRouteOutdated(nad *cniv1.NetworkAttachmentDefinition, oldConf, newConf *utils.NetConf) (types.Patch, error) {
+	if oldConf.BrName == newConf.BrName && oldConf.Vlan == newConf.Vlan {
+		return nil, nil
+	}
+
+	annotations := nad.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	klog.Infof("new config: %+v", newConf)
+
+	if newConf.Vlan == 0 {
+		delete(annotations, utils.KeyNetworkRoute)
+	} else {
+		layer3NetworkConf := utils.Layer3NetworkConf{}
+		routeAnnotation := nad.Annotations[utils.KeyNetworkRoute]
+		if err := json.Unmarshal([]byte(routeAnnotation), &layer3NetworkConf); err != nil {
+			return nil, err
+		}
+
+		if layer3NetworkConf.Mode != utils.Auto {
+			return nil, nil
+		}
+
+		layer3NetworkConf.Outdated = true
+
+		outdatedRoute, err := json.Marshal(layer3NetworkConf)
+		if err != nil {
+			return nil, err
+		}
+		annotations[utils.KeyNetworkRoute] = string(outdatedRoute)
+	}
+
+	return types.Patch{
+		types.PatchOp{
+			Op:    types.PatchOpReplace,
+			Path:  "/metadata/annotations",
+			Value: annotations,
+		},
+	}, nil
+}

--- a/pkg/webhook/nad/mutator.go
+++ b/pkg/webhook/nad/mutator.go
@@ -82,6 +82,11 @@ func (n *NadMutator) ensureLabels(nad *cniv1.NetworkAttachmentDefinition, oldCon
 		labels = make(map[string]string)
 	}
 
+	// Ignore untagged network because we don't need to do more operation if the last network type is untagged network
+	if oldConf.Vlan != 0 && newConf.Vlan == 0 {
+		labels[utils.KeyLastNetworkType] = string(utils.L2VlanNetwork)
+	}
+
 	if newConf.Vlan != 0 {
 		labels[utils.KeyNetworkType] = string(utils.L2VlanNetwork)
 		labels[utils.KeyVlanLabel] = strconv.Itoa(newConf.Vlan)
@@ -89,6 +94,7 @@ func (n *NadMutator) ensureLabels(nad *cniv1.NetworkAttachmentDefinition, oldCon
 		labels[utils.KeyNetworkType] = string(utils.UntaggedNetwork)
 		delete(labels, utils.KeyVlanLabel)
 	}
+
 	if oldConf.Vlan != 0 && oldConf.Vlan != newConf.Vlan {
 		labels[utils.KeyLastVlanLabel] = strconv.Itoa(oldConf.Vlan)
 	}
@@ -130,7 +136,7 @@ func tagRouteOutdated(nad *cniv1.NetworkAttachmentDefinition, oldConf, newConf *
 		delete(annotations, utils.KeyNetworkRoute)
 	} else {
 		layer3NetworkConf := utils.Layer3NetworkConf{}
-		routeAnnotation := nad.Annotations[utils.KeyNetworkRoute]
+		routeAnnotation := annotations[utils.KeyNetworkRoute]
 		if err := json.Unmarshal([]byte(routeAnnotation), &layer3NetworkConf); err != nil {
 			return nil, err
 		}

--- a/pkg/webhook/nad/validator.go
+++ b/pkg/webhook/nad/validator.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	ctlkubevirtv1 "github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io/v1"
-	"github.com/harvester/harvester/pkg/indexeres"
 	"github.com/harvester/webhook/pkg/types"
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
@@ -24,80 +23,95 @@ const (
 
 type Validator struct {
 	types.DefaultValidator
-	vmCache ctlkubevirtv1.VirtualMachineCache
+	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache
 }
 
 var _ types.Validator = &Validator{}
 
-func NewNadValidator(vmCache ctlkubevirtv1.VirtualMachineCache) *Validator {
+func NewNadValidator(vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) *Validator {
 	return &Validator{
-		vmCache: vmCache,
+		vmiCache: vmiCache,
 	}
 }
 
 func (n *Validator) Create(_ *types.Request, newObj runtime.Object) error {
-	netAttachDef := newObj.(*cniv1.NetworkAttachmentDefinition)
+	nad := newObj.(*cniv1.NetworkAttachmentDefinition)
 
-	config := netAttachDef.Spec.Config
-	if config == "" {
-		return fmt.Errorf(createErr, netAttachDef.Namespace, netAttachDef.Name, fmt.Errorf("spec.config is empty"))
-	}
-
-	var bridgeConf = &utils.NetConf{}
-	err := json.Unmarshal([]byte(config), &bridgeConf)
-	if err != nil {
-		return fmt.Errorf(createErr, netAttachDef.Namespace, netAttachDef.Name, err)
-	}
-
-	// The VLAN value of untagged network will be empty or number 0.
-	if bridgeConf.Vlan < 0 || bridgeConf.Vlan > 4094 {
-		return fmt.Errorf(createErr, netAttachDef.Namespace, netAttachDef.Name, fmt.Errorf("VLAN ID must >=0 and <=4094"))
-	}
-
-	lenOfBrName, lenOfBridgeSuffix := len(bridgeConf.BrName), len(iface.BridgeSuffix)
-	if lenOfBrName > iface.MaxDeviceNameLen {
-		return fmt.Errorf(createErr, netAttachDef.Namespace, netAttachDef.Name, fmt.Errorf("the length of the brName could not be more than 15"))
-	}
-	if lenOfBrName <= lenOfBridgeSuffix || bridgeConf.BrName[lenOfBrName-lenOfBridgeSuffix:] != iface.BridgeSuffix {
-		return fmt.Errorf(createErr, netAttachDef.Namespace, netAttachDef.Name, fmt.Errorf("the suffix of the brName should be -br"))
+	if err := n.checkNadConfig(nad.Spec.Config); err != nil {
+		return fmt.Errorf(createErr, nad.Namespace, nad.Name, err)
 	}
 
 	return nil
 }
 
 func (n *Validator) Update(_ *types.Request, oldObj, newObj runtime.Object) error {
-	oldNad, newNad := oldObj.(*cniv1.NetworkAttachmentDefinition), newObj.(*cniv1.NetworkAttachmentDefinition)
+	newNad := newObj.(*cniv1.NetworkAttachmentDefinition)
 
-	if oldNad.Spec.Config != newNad.Spec.Config {
-		return fmt.Errorf(updateErr, oldNad.Namespace, oldNad.Name, fmt.Errorf("it's not allowed to modify config"))
+	if newNad.DeletionTimestamp != nil {
+		return nil
+	}
+
+	if err := n.checkNadConfig(newNad.Spec.Config); err != nil {
+		return fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
+	}
+
+	if err := n.checkVmi(newNad); err != nil {
+		return fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
 	}
 
 	return nil
 }
 
 func (n *Validator) Delete(_ *types.Request, oldObj runtime.Object) error {
-	netAttachDef := oldObj.(*cniv1.NetworkAttachmentDefinition)
+	nad := oldObj.(*cniv1.NetworkAttachmentDefinition)
 
-	// multus network name can be <networkName> or <namespace>/<networkName>
-	// ref: https://github.com/kubevirt/client-go/blob/148fa0d1c7e83b7a56606a7ca92394ba6768c9ac/api/v1/schema.go#L1436-L1439
-	networkName := fmt.Sprintf("%s/%s", netAttachDef.Namespace, netAttachDef.Name)
-	vms, err := n.vmCache.GetByIndex(indexeres.VMByNetworkIndex, networkName)
-	if err != nil {
-		return fmt.Errorf(deleteErr, netAttachDef.Namespace, networkName, err)
-	}
-	vmsTmp, err := n.vmCache.GetByIndex(indexeres.VMByNetworkIndex, netAttachDef.Name)
-	if err != nil {
-		return fmt.Errorf(deleteErr, netAttachDef.Namespace, networkName, err)
+	if err := n.checkVmi(nad); err != nil {
+		return fmt.Errorf(deleteErr, nad.Namespace, nad.Name, err)
 	}
 
-	vms = append(vms, vmsTmp...)
+	return nil
+}
 
-	if len(vms) > 0 {
-		vmNameList := make([]string, 0, len(vms))
-		for _, vm := range vms {
-			vmNameList = append(vmNameList, vm.Name)
+func (n *Validator) checkNadConfig(config string) error {
+	if config == "" {
+		return fmt.Errorf("config is empty")
+	}
+
+	var bridgeConf = &utils.NetConf{}
+	err := json.Unmarshal([]byte(config), &bridgeConf)
+	if err != nil {
+		return err
+	}
+
+	// The VLAN value of untagged network will be empty or number 0.
+	if bridgeConf.Vlan < 0 || bridgeConf.Vlan > 4094 {
+		return fmt.Errorf("VLAN ID must >=0 and <=4094")
+	}
+
+	lenOfBrName, lenOfBridgeSuffix := len(bridgeConf.BrName), len(iface.BridgeSuffix)
+	if lenOfBrName > iface.MaxDeviceNameLen {
+		return fmt.Errorf("the length of the brName could not be more than 15")
+	}
+	if lenOfBrName <= lenOfBridgeSuffix || bridgeConf.BrName[lenOfBrName-lenOfBridgeSuffix:] != iface.BridgeSuffix {
+		return fmt.Errorf("the suffix of the brName should be -br")
+	}
+
+	return nil
+}
+
+func (n *Validator) checkVmi(nad *cniv1.NetworkAttachmentDefinition) error {
+	vmiGetter := utils.VmiGetter{VmiCache: n.vmiCache}
+	vmis, err := vmiGetter.WhoUseNad(nad, nil)
+	if err != nil {
+		return err
+	}
+
+	if len(vmis) > 0 {
+		vmiNameList := make([]string, 0, len(vmis))
+		for _, vmi := range vmis {
+			vmiNameList = append(vmiNameList, vmi.Namespace+"/"+vmi.Name)
 		}
-		return fmt.Errorf(deleteErr, netAttachDef.Namespace, netAttachDef.Name, fmt.Errorf("it's still used by vm(s): %s", strings.Join(vmNameList, ", ")))
+		return fmt.Errorf("it's still used by VM(s) %s which must be stopped at first", strings.Join(vmiNameList, ", "))
 	}
 
 	return nil

--- a/pkg/webhook/nad/validator.go
+++ b/pkg/webhook/nad/validator.go
@@ -34,45 +34,45 @@ func NewNadValidator(vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) *Valida
 	}
 }
 
-func (n *Validator) Create(_ *types.Request, newObj runtime.Object) error {
+func (v *Validator) Create(_ *types.Request, newObj runtime.Object) error {
 	nad := newObj.(*cniv1.NetworkAttachmentDefinition)
 
-	if err := n.checkNadConfig(nad.Spec.Config); err != nil {
+	if err := v.checkNadConfig(nad.Spec.Config); err != nil {
 		return fmt.Errorf(createErr, nad.Namespace, nad.Name, err)
 	}
 
 	return nil
 }
 
-func (n *Validator) Update(_ *types.Request, oldObj, newObj runtime.Object) error {
+func (v *Validator) Update(_ *types.Request, oldObj, newObj runtime.Object) error {
 	newNad := newObj.(*cniv1.NetworkAttachmentDefinition)
 
 	if newNad.DeletionTimestamp != nil {
 		return nil
 	}
 
-	if err := n.checkNadConfig(newNad.Spec.Config); err != nil {
+	if err := v.checkNadConfig(newNad.Spec.Config); err != nil {
 		return fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
 	}
 
-	if err := n.checkVmi(newNad); err != nil {
+	if err := v.checkVmi(newNad); err != nil {
 		return fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
 	}
 
 	return nil
 }
 
-func (n *Validator) Delete(_ *types.Request, oldObj runtime.Object) error {
+func (v *Validator) Delete(_ *types.Request, oldObj runtime.Object) error {
 	nad := oldObj.(*cniv1.NetworkAttachmentDefinition)
 
-	if err := n.checkVmi(nad); err != nil {
+	if err := v.checkVmi(nad); err != nil {
 		return fmt.Errorf(deleteErr, nad.Namespace, nad.Name, err)
 	}
 
 	return nil
 }
 
-func (n *Validator) checkNadConfig(config string) error {
+func (v *Validator) checkNadConfig(config string) error {
 	if config == "" {
 		return fmt.Errorf("config is empty")
 	}
@@ -99,8 +99,8 @@ func (n *Validator) checkNadConfig(config string) error {
 	return nil
 }
 
-func (n *Validator) checkVmi(nad *cniv1.NetworkAttachmentDefinition) error {
-	vmiGetter := utils.VmiGetter{VmiCache: n.vmiCache}
+func (v *Validator) checkVmi(nad *cniv1.NetworkAttachmentDefinition) error {
+	vmiGetter := utils.VmiGetter{VmiCache: v.vmiCache}
 	vmis, err := vmiGetter.WhoUseNad(nad, nil)
 	if err != nil {
 		return err
@@ -117,7 +117,7 @@ func (n *Validator) checkVmi(nad *cniv1.NetworkAttachmentDefinition) error {
 	return nil
 }
 
-func (n *Validator) Resource() types.Resource {
+func (v *Validator) Resource() types.Resource {
 	return types.Resource{
 		Names:      []string{"network-attachment-definitions"},
 		Scope:      admissionregv1.NamespacedScope,

--- a/pkg/webhook/vlanconfig/mutator.go
+++ b/pkg/webhook/vlanconfig/mutator.go
@@ -14,21 +14,21 @@ import (
 	"github.com/harvester/harvester-network-controller/pkg/utils"
 )
 
-type Mutator struct {
+type VlanConfigMutator struct {
 	types.DefaultMutator
 
 	nodeCache ctlcorev1.NodeCache
 }
 
-var _ types.Mutator = &Mutator{}
+var _ types.Mutator = &VlanConfigMutator{}
 
-func NewNadMutator(nodeCache ctlcorev1.NodeCache) *Mutator {
-	return &Mutator{
+func NewVlanConfigMutator(nodeCache ctlcorev1.NodeCache) *VlanConfigMutator {
+	return &VlanConfigMutator{
 		nodeCache: nodeCache,
 	}
 }
 
-func (v *Mutator) Create(_ *types.Request, newObj runtime.Object) (types.Patch, error) {
+func (v *VlanConfigMutator) Create(_ *types.Request, newObj runtime.Object) (types.Patch, error) {
 	vlanConfig := newObj.(*networkv1.VlanConfig)
 
 	annotationPatch, err := v.matchNodes(vlanConfig)
@@ -39,9 +39,9 @@ func (v *Mutator) Create(_ *types.Request, newObj runtime.Object) (types.Patch, 
 	return append(getCnLabelPatch(vlanConfig), annotationPatch...), nil
 }
 
-func (v *Mutator) Update(_ *types.Request, oldObj, newObj runtime.Object) (types.Patch, error) {
+func (v *VlanConfigMutator) Update(_ *types.Request, oldObj, newObj runtime.Object) (types.Patch, error) {
 	newVc := newObj.(*networkv1.VlanConfig)
-	oldVc := newObj.(*networkv1.VlanConfig)
+	oldVc := oldObj.(*networkv1.VlanConfig)
 
 	var cnLabelPatch, annotationPatch types.Patch
 	if newVc.Spec.ClusterNetwork != oldVc.Spec.ClusterNetwork {
@@ -75,7 +75,7 @@ func getCnLabelPatch(v *networkv1.VlanConfig) types.Patch {
 		}}
 }
 
-func (v *Mutator) matchNodes(vc *networkv1.VlanConfig) (types.Patch, error) {
+func (v *VlanConfigMutator) matchNodes(vc *networkv1.VlanConfig) (types.Patch, error) {
 	nodes, err := v.nodeCache.List(labels.Set(vc.Spec.NodeSelector).AsSelector())
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func matchedNodesToPatch(vc *networkv1.VlanConfig, matchedNodes []string) (types
 	}, nil
 }
 
-func (v *Mutator) Resource() types.Resource {
+func (v *VlanConfigMutator) Resource() types.Resource {
 	return types.Resource{
 		Names:      []string{"vlanconfigs"},
 		Scope:      admissionregv1.ClusterScope,


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/3372
Solution: 
- Add a mutating webhook to record the outdated cluster network and VLAN id by `network.harvesterhci.io/last-clusternetwork` and `network.harvesterhci.io/last-vlan-id`. Then controllers are able to know the outdated VLAN id and cluster network to do the cleanup process including deleting the related bridge configuration and route job. 
- All related running VMs need to be stopped before updating VM networks and vlanconfigs. The validating webhook is responsible for the VM checking.
- Indicate the ready status of VM networks by the label `network.harvesterhci.io/ready`. Once the cluster network is unready(no vlanconfig in effect)  , the nad under the cluster network will be unready and can't be used by running VMs.