### PR TITLE
Mask of CIDR could not be zero

### DIFF
--- a/pkg/utils/nad.go
+++ b/pkg/utils/nad.go
@@ -58,7 +58,8 @@ func NewLayer3NetworkConf(conf string) (*Layer3NetworkConf, error) {
 	if networkConf.Mode != "" && networkConf.Mode != Auto && networkConf.Mode != Manual {
 		return nil, fmt.Errorf("unknown mode %s", networkConf.Mode)
 	}
-	if _, ipnet, err := net.ParseCIDR(networkConf.CIDR); networkConf.CIDR != "" && (err != nil || (ipnet != nil && isMaskZero(ipnet))) {
+	_, ipnet, err := net.ParseCIDR(networkConf.CIDR)
+	if err != nil || (ipnet != nil && isMaskZero(ipnet)) {
 		return nil, fmt.Errorf("the CIDR %s is invalid", networkConf.CIDR)
 	}
 	if networkConf.Mode == Manual && networkConf.Gateway != "" && net.ParseIP(networkConf.Gateway) == nil {

--- a/pkg/utils/nad.go
+++ b/pkg/utils/nad.go
@@ -44,10 +44,14 @@ type Layer3NetworkConf struct {
 }
 
 func NewLayer3NetworkConf(conf string) (*Layer3NetworkConf, error) {
+	if conf == "" {
+		return &Layer3NetworkConf{}, nil
+	}
+
 	networkConf := &Layer3NetworkConf{}
 
 	if err := json.Unmarshal([]byte(conf), networkConf); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal %s faield, error: %w", conf, err)
 	}
 
 	// validate
@@ -55,10 +59,10 @@ func NewLayer3NetworkConf(conf string) (*Layer3NetworkConf, error) {
 		return nil, fmt.Errorf("unknown mode %s", networkConf.Mode)
 	}
 	if _, ipnet, err := net.ParseCIDR(networkConf.CIDR); networkConf.CIDR != "" && (err != nil || (ipnet != nil && isMaskZero(ipnet))) {
-		return nil, fmt.Errorf("invalid CIDR %s", networkConf.CIDR)
+		return nil, fmt.Errorf("the CIDR %s is invalid", networkConf.CIDR)
 	}
 	if networkConf.Mode == Manual && networkConf.Gateway != "" && net.ParseIP(networkConf.Gateway) == nil {
-		return nil, fmt.Errorf("invalid gateway %s", networkConf.Gateway)
+		return nil, fmt.Errorf("the gateway %s is invalid", networkConf.Gateway)
 	}
 
 	return networkConf, nil

--- a/pkg/webhook/nad/mutator.go
+++ b/pkg/webhook/nad/mutator.go
@@ -137,8 +137,8 @@ func tagRouteOutdated(nad *cniv1.NetworkAttachmentDefinition, oldConf, newConf *
 	} else {
 		layer3NetworkConf := utils.Layer3NetworkConf{}
 		routeAnnotation := annotations[utils.KeyNetworkRoute]
-		if err := json.Unmarshal([]byte(routeAnnotation), &layer3NetworkConf); err != nil {
-			return nil, err
+		if err := json.Unmarshal([]byte(routeAnnotation), &layer3NetworkConf); routeAnnotation != "" && err != nil {
+			return nil, fmt.Errorf("unmarshal %s failed, error: %w", routeAnnotation, err)
 		}
 
 		if layer3NetworkConf.Mode != utils.Auto {
@@ -149,7 +149,7 @@ func tagRouteOutdated(nad *cniv1.NetworkAttachmentDefinition, oldConf, newConf *
 
 		outdatedRoute, err := json.Marshal(layer3NetworkConf)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("marshal %v failed, error: %w", layer3NetworkConf, err)
 		}
 		annotations[utils.KeyNetworkRoute] = string(outdatedRoute)
 	}

--- a/pkg/webhook/nad/validator.go
+++ b/pkg/webhook/nad/validator.go
@@ -84,7 +84,7 @@ func (v *Validator) checkNadConfig(config string) error {
 	var bridgeConf = &utils.NetConf{}
 	err := json.Unmarshal([]byte(config), &bridgeConf)
 	if err != nil {
-		return err
+		return fmt.Errorf("unmarshal %s failed, error: %w", config, err)
 	}
 
 	// The VLAN value of untagged network will be empty or number 0.


### PR DESCRIPTION
The PR solves two problems.
1. Related issue: https://github.com/harvester/harvester/issues/3615
When the mask of CIDR is zero, the route to be deleted would be the default route. We could not delete the default route.

2. Related problem: https://github.com/harvester/harvester/issues/3440#issuecomment-1461784744
It's introduced by the PR https://github.com/harvester/network-controller-harvester/pull/76. 
When the route is empty, it should return nil when checking the route.
