### PR TITLE
fix CIDR and gateway validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+**Problem:**
+<!-- Explain the problem you are aiming to resolve in this PR. -->
+
+**Solution:**
+<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
+
+**Related Issue:**
+
+**Test plan:**
+<!-- Make sure tests pass on the Circle CI. -->
+

--- a/pkg/utils/nad.go
+++ b/pkg/utils/nad.go
@@ -58,12 +58,17 @@ func NewLayer3NetworkConf(conf string) (*Layer3NetworkConf, error) {
 	if networkConf.Mode != "" && networkConf.Mode != Auto && networkConf.Mode != Manual {
 		return nil, fmt.Errorf("unknown mode %s", networkConf.Mode)
 	}
-	_, ipnet, err := net.ParseCIDR(networkConf.CIDR)
-	if err != nil || (ipnet != nil && isMaskZero(ipnet)) {
-		return nil, fmt.Errorf("the CIDR %s is invalid", networkConf.CIDR)
-	}
-	if networkConf.Mode == Manual && networkConf.Gateway != "" && net.ParseIP(networkConf.Gateway) == nil {
-		return nil, fmt.Errorf("the gateway %s is invalid", networkConf.Gateway)
+
+	// validate cidr and gateway when the mode is manual
+	if networkConf.Mode == Manual {
+		_, ipnet, err := net.ParseCIDR(networkConf.CIDR)
+		if err != nil || (ipnet != nil && isMaskZero(ipnet)) {
+			return nil, fmt.Errorf("the CIDR %s is invalid", networkConf.CIDR)
+		}
+
+		if net.ParseIP(networkConf.Gateway) == nil {
+			return nil, fmt.Errorf("the gateway %s is invalid", networkConf.Gateway)
+		}
 	}
 
 	return networkConf, nil


### PR DESCRIPTION
**Description:**
When you try to create a VM network, it gives you a webhook validation CIDR error on submission per https://github.com/harvester/harvester/issues/3629


**Solution:**
should validate both CIDR and gateway value when the NAD's route config mode is manual.



**Related Issue:**
https://github.com/harvester/harvester/issues/3629