### PR TITLE
Avoid bond from recreating periodically

### DIFF
--- a/manifests/crds/network.harvesterhci.io_vlanconfigs.yaml
+++ b/manifests/crds/network.harvesterhci.io_vlanconfigs.yaml
@@ -57,11 +57,14 @@ spec:
               uplink:
                 properties:
                   bondOptions:
-                    description: 'TODO: reference: https://www.kernel.org/doc/Documentation/networking/bonding.txt'
+                    description: 'reference: https://www.kernel.org/doc/Documentation/networking/bonding.txt'
                     properties:
                       miimon:
+                        default: -1
+                        minimum: -1
                         type: integer
                       mode:
+                        default: active-backup
                         enum:
                         - balance-rr
                         - active-backup
@@ -80,8 +83,11 @@ spec:
                         format: byte
                         type: string
                       mtu:
+                        minimum: 0
                         type: integer
                       txQLen:
+                        default: -1
+                        minimum: -1
                         type: integer
                     type: object
                   nics:

--- a/pkg/apis/network.harvesterhci.io/v1beta1/vlanconfig.go
+++ b/pkg/apis/network.harvesterhci.io/v1beta1/vlanconfig.go
@@ -38,22 +38,29 @@ type Uplink struct {
 
 type LinkAttrs struct {
 	// +optional
+	// +kubebuilder:validation:Minimum:=0
 	MTU int `json:"mtu,omitempty"`
 	// +optional
+	// +kubebuilder:validation:Minimum:=-1
+	// +kubebuilder:default:=-1
 	TxQLen int `json:"txQLen,omitempty"`
 	// +optional
 	HardwareAddr net.HardwareAddr `json:"hardwareAddr,omitempty"`
 }
 
-// TODO: reference: https://www.kernel.org/doc/Documentation/networking/bonding.txt
+// reference: https://www.kernel.org/doc/Documentation/networking/bonding.txt
 type BondOptions struct {
 	// +optional
+	// +kubebuilder:default:="active-backup"
 	Mode BondMode `json:"mode,omitempty"`
 	// +optional
+	// +kubebuilder:validation:Minimum:=-1
+	// +kubebuilder:default:=-1
 	Miimon int `json:"miimon,omitempty"`
 }
 
 // +kubebuilder:validation:Enum={"balance-rr","active-backup","balance-xor","broadcast","802.3ad","balance-tlb","balance-alb"}
+
 type BondMode string
 
 const (

--- a/pkg/controller/agent/vlanconfig/controller.go
+++ b/pkg/controller/agent/vlanconfig/controller.go
@@ -243,12 +243,8 @@ func setUplink(vc *networkv1.VlanConfig) (*iface.Link, error) {
 	linkAttrs := netlink.NewLinkAttrs()
 	linkAttrs.Name = vc.Spec.ClusterNetwork + iface.BondSuffix
 	if vc.Spec.Uplink.LinkAttrs != nil {
-		if vc.Spec.Uplink.LinkAttrs.MTU != 0 {
-			linkAttrs.MTU = vc.Spec.Uplink.LinkAttrs.MTU
-		}
-		if vc.Spec.Uplink.LinkAttrs.TxQLen != 0 {
-			linkAttrs.TxQLen = vc.Spec.Uplink.LinkAttrs.TxQLen
-		}
+		linkAttrs.MTU = vc.Spec.Uplink.LinkAttrs.MTU
+		linkAttrs.TxQLen = vc.Spec.Uplink.LinkAttrs.TxQLen
 		if vc.Spec.Uplink.LinkAttrs.HardwareAddr != nil {
 			linkAttrs.HardwareAddr = vc.Spec.Uplink.LinkAttrs.HardwareAddr
 		}
@@ -262,7 +258,7 @@ func setUplink(vc *networkv1.VlanConfig) (*iface.Link, error) {
 	}
 	bond.Mode = mode
 	// set bonding miimon
-	if vc.Spec.Uplink.BondOptions != nil && vc.Spec.Uplink.BondOptions.Miimon != 0 {
+	if vc.Spec.Uplink.BondOptions != nil {
 		bond.Miimon = vc.Spec.Uplink.BondOptions.Miimon
 	}
 

--- a/pkg/generated/clientset/versioned/fake/register.go
+++ b/pkg/generated/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/generated/clientset/versioned/scheme/register.go
+++ b/pkg/generated/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/generated/controllers/network.harvesterhci.io/factory.go
+++ b/pkg/generated/controllers/network.harvesterhci.io/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package network
 
 import (
+	"github.com/rancher/lasso/pkg/controller"
 	"github.com/rancher/wrangler/pkg/generic"
 	"k8s.io/client-go/rest"
 )
@@ -64,4 +65,8 @@ func NewFactoryFromConfigWithOptionsOrDie(config *rest.Config, opts *FactoryOpti
 
 func (c *Factory) Network() Interface {
 	return New(c.ControllerFactory())
+}
+
+func (c *Factory) WithAgent(userAgent string) Interface {
+	return New(controller.NewSharedControllerFactoryWithAgent(userAgent, c.ControllerFactory()))
 }

--- a/pkg/network/iface/bond.go
+++ b/pkg/network/iface/bond.go
@@ -166,10 +166,28 @@ func getSlaves(index int) ([]netlink.Link, error) {
 }
 
 func compareBond(b1, b2 *netlink.Bond) bool {
-	if b1.Name == b2.Name && b1.MTU == b2.MTU && b1.Mode == b2.Mode &&
-		b1.HardwareAddr.String() == b2.HardwareAddr.String() && b1.TxQLen == b2.TxQLen {
-		return true
+	if b1.Name != b2.Name {
+		return false
 	}
 
-	return false
+	if b1.Mode != b2.Mode {
+		return false
+	}
+
+	// skip if mtu is omitted
+	if b2.MTU != 0 && b1.MTU != b2.MTU {
+		return false
+	}
+
+	// skip if hardware addr is omitted
+	if b2.HardwareAddr.String() != "" && b1.HardwareAddr.String() != b2.HardwareAddr.String() {
+		return false
+	}
+
+	// skip if TxQLen is omitted, default value -1
+	if b2.TxQLen != -1 && b1.TxQLen != b2.TxQLen {
+		return false
+	}
+
+	return true
 }

--- a/pkg/network/iface/bond.go
+++ b/pkg/network/iface/bond.go
@@ -165,27 +165,34 @@ func getSlaves(index int) ([]netlink.Link, error) {
 	return links, nil
 }
 
-func compareBond(b1, b2 *netlink.Bond) bool {
-	if b1.Name != b2.Name {
+func compareBond(old, new *netlink.Bond) bool {
+	if old.Name != new.Name {
 		return false
 	}
 
-	if b1.Mode != b2.Mode {
+	if old.Mode != new.Mode {
 		return false
 	}
 
 	// skip if mtu is omitted
-	if b2.MTU != 0 && b1.MTU != b2.MTU {
+	if new.MTU != 0 && old.MTU != new.MTU {
 		return false
 	}
 
 	// skip if hardware addr is omitted
-	if b2.HardwareAddr.String() != "" && b1.HardwareAddr.String() != b2.HardwareAddr.String() {
+	if new.HardwareAddr.String() != "" && old.HardwareAddr.String() != new.HardwareAddr.String() {
 		return false
 	}
 
 	// skip if TxQLen is omitted, default value -1
-	if b2.TxQLen != -1 && b1.TxQLen != b2.TxQLen {
+	// -1 means to keep the original TxQLen value, so we have to skip it to avoid unnecessary bond recreating.
+	if new.TxQLen != -1 && old.TxQLen != new.TxQLen {
+		return false
+	}
+
+	// skip if Miimon is omitted, default value -1
+	// Same logic with TxQLen
+	if new.Miimon != -1 && old.Miimon != new.Miimon {
 		return false
 	}
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The bond will recreate every 10 hour and cause network flapping. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Set default value in the CRD
- Ignore the default value when judging whether there is a parameter change

**Related Issue:** https://github.com/harvester/harvester/issues/3744

**Dependency:** https://github.com/harvester/charts/pull/155

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Create a new cluster network and create the related vlanconfig. The default value of miimon and TxQLen is -1. -1 means to keep the original value which may be system default value or set manually before.
- Delete harvester network controller pod, watch `dmesg -T`, the bond will not be recreated.

