### PR TITLE
Disable iptables bridge forwarding on initialization

### DIFF
--- a/pkg/network/iface/bridge.go
+++ b/pkg/network/iface/bridge.go
@@ -31,10 +31,6 @@ func NewBridge(name string) *Bridge {
 // Ensure bridge
 // set promiscuous mod default
 func (br *Bridge) Ensure() error {
-	if err := disableBridgeNF(); err != nil {
-		return fmt.Errorf("disable net.bridge.bridge-nf-call-iptables failed, error: %w", err)
-	}
-
 	if err := netlink.LinkAdd(br); err != nil && err != syscall.EEXIST {
 		return fmt.Errorf("add iface failed, error: %w, iface: %v", err, br)
 	}
@@ -67,7 +63,7 @@ func (br *Bridge) Ensure() error {
 	return br.Fetch()
 }
 
-func disableBridgeNF() error {
+func DisableBridgeNF() error {
 	return utils.EnsureSysctlValue(bridgeNFCallIptables, "0")
 }
 

--- a/pkg/network/vlan/vlan.go
+++ b/pkg/network/vlan/vlan.go
@@ -142,3 +142,9 @@ func (v *Vlan) Bridge() *iface.Bridge {
 func (v *Vlan) Uplink() *iface.Link {
 	return v.uplink
 }
+
+func init() {
+	if err := iface.DisableBridgeNF(); err != nil {
+		klog.Fatalf("disable net.bridge.bridge-nf-call-iptables failed, error: %v", err)
+	}
+}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
In the Harvester cluster whose management network has a VLAN ID, the VM will be unable to access the host port or node port with the host IP where the VM is running.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Disable net.bridge.bridge-nf-call-iptables to avoid iptables rules affecting bridge forwarding on vlan.init().

We could not disable net.bridge.bridge-nf-call-iptables in the harvester-installer because RKE2 will enable it after harvester-installer.

**Related Issue:** https://github.com/harvester/harvester/issues/3960

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Spin up a Harvester whose management network has a VLAN ID
- Create a VM with VLAN network whose VLAN ID is same with the management network.
- Curl nodeIP:443 in the VM.

