### PR TITLE
feat: bump SLE to 15.5

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 RUN zypper -n rm container-suseconnect && \
     zypper install -y iptables=1.8.7 && \
     zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*

--- a/package/Dockerfile.helper
+++ b/package/Dockerfile.helper
@@ -1,3 +1,3 @@
-FROM registry.suse.com/bci/bci-minimal:15.4
+FROM registry.suse.com/bci/bci-minimal:15.5
 COPY bin/harvester-network-helper /usr/bin/
 CMD ["harvester-network-helper"]

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -1,3 +1,3 @@
-FROM registry.suse.com/bci/bci-minimal:15.4
+FROM registry.suse.com/bci/bci-minimal:15.5
 COPY bin/harvester-network-webhook /usr/bin/
 CMD ["harvester-network-webhook"]


### PR DESCRIPTION
**Problem:**
SLE 15 SP4 general ends on 31 Dec 2023.

**Solution:**
Bump SLE BCI images to to 15.5.

**Related Issue:**
https://github.com/harvester/harvester/issues/4757

**Test plan:**
Test basic operation can work.
