### PR TITLE
feat: bump golangci-lint to v1.55.2

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -6,7 +6,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 RUN zypper -n rm container-suseconnect && \
     zypper -n install git curl docker gzip tar wget awk
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2
 
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG


### PR DESCRIPTION
**Problem:**
The golangci-lint version before v1.51.0 may have OOM issue with golang v1.20.

**Solution:**
Bump golangci-lint to a version after v1.51.0.

**Related Issue:**
https://github.com/harvester/harvester/issues/4938
