### PR TITLE
fix: http(s) connection time out from VMs in VLAN netwok

### DIFF
--- a/pkg/network/iface/link.go
+++ b/pkg/network/iface/link.go
@@ -63,6 +63,26 @@ func (l *Link) DelBridgeVlan(vid uint16) error {
 	return nil
 }
 
+func (l *Link) IsBridgeVlanPVID(vid uint16) bool {
+	m, err := netlink.BridgeVlanList()
+	if err != nil {
+		return false
+	}
+
+	vlanInfo, ok := m[int32(l.Attrs().Index)]
+	if !ok {
+		return false
+	}
+
+	for i := range vlanInfo {
+		if vid == vlanInfo[i].Vid {
+			return vlanInfo[i].PortVID()
+		}
+	}
+
+	return false
+}
+
 func (l *Link) ListBridgeVlan() ([]uint16, error) {
 	m, err := netlink.BridgeVlanList()
 	if err != nil {


### PR DESCRIPTION
**Problem:**
The VM attached to the VLAN network fails to http(s) with management URL. However, there's no problem with SSH/ping which connect to ports other then http(s) since http(s) needs extra route to the CNI interface.

**Solution:**
The http(s) egress from the uplink bridge interface should be untagged to be correctly routed. Since the routing is determined is based on L3, but the VLAN packet is L2.

**Related Issue:**
https://github.com/harvester/harvester/issues/4359

