### PR TITLE
webhook/mutator: filter out the witness node

### DIFF
--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -20,4 +20,6 @@ const (
 
 	ValueTrue  = "true"
 	ValueFalse = "false"
+
+	HarvesterWitnessNodeLabelKey = "node-role.harvesterhci.io/witness"
 )


### PR DESCRIPTION
 **Problem:**
The matched-node returns the whole nodes even if we have one witness node.
The witness node did not run any workload, so we should filter out this.

**Solution:**
we do not allow any workload on the witness node, so we should filter out the witness node when creating the vlan config.

**Related Issue:**
https://github.com/harvester/harvester/issues/5325#issuecomment-2236668074

**Test plan:**
Make sure the annotation of vlanconfig response should looks like below (harvester-node-1 is the witness node)
```
annotations: {network.harvesterhci.io/matched-nodes: "["harvester-node-0","harvester-node-2"]"}
``` 

