### PR TITLE
controller/node: skip update vlanconfig with witness node

### DIFF
--- a/pkg/controller/manager/node/controller.go
+++ b/pkg/controller/manager/node/controller.go
@@ -61,6 +61,11 @@ func (h Handler) OnChange(_ string, node *corev1.Node) (*corev1.Node, error) {
 		return nil, err
 	}
 
+	// skip witness node because we do not allow vlan config on witness node
+	if node.Labels != nil && node.Labels[utils.HarvesterWitnessNodeLabelKey] == "true" {
+		return nil, nil
+	}
+
 	vcs, err := h.vcCache.List(labels.Everything())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Problem:**
Now, the `matched-nodes` will filter out the witness node with creation.
However, the controller has a chance to update the witness node to the `matched-nodes` on the controller part.

**Solution:**
We need to skip to update the `matched-nodes` with the witness node change.

**Related Issue:**
https://github.com/harvester/network-controller-harvester/pull/104#issuecomment-2268030300

**Test plan:**
Make sure the `matched-nodes` annotation of vlanconfig does not contain any witness node.

