### PR TITLE
network-controller-harvester: bump golang v1.22

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.21
+FROM registry.suse.com/bci/golang:1.22
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-network-controller
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.18


### PR DESCRIPTION
**Problem:**
Go v1.21 is going to be EOL soon.

**Solution:**
Bump go version to v1.22

**Related Issue:**
https://github.com/harvester/harvester/issues/6160

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

