### PR TITLE
3826 backport Add validation for clusternetwork name length 

### DIFF
--- a/pkg/controller/manager/node/controller.go
+++ b/pkg/controller/manager/node/controller.go
@@ -61,6 +61,11 @@ func (h Handler) OnChange(_ string, node *corev1.Node) (*corev1.Node, error) {
 		return nil, err
 	}
 
+	// skip witness node because we do not allow vlan config on witness node
+	if node.Labels != nil && node.Labels[utils.HarvesterWitnessNodeLabelKey] == "true" {
+		return nil, nil
+	}
+
 	vcs, err := h.vcCache.List(labels.Everything())
 	if err != nil {
 		return nil, err

--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -20,4 +20,6 @@ const (
 
 	ValueTrue  = "true"
 	ValueFalse = "false"
+
+	HarvesterWitnessNodeLabelKey = "node-role.harvesterhci.io/witness"
 )


### PR DESCRIPTION
**Problem:**
cluster network name length is not validated for maximum length for 12 chars when created using API.
Webhook validator of cluster network is missing validation.

**Solution:**
Added validation for checking maximum cluster network name length in webhook validator of cluster network

**Related Issue:**

**Test plan:**
Tested manually on harvester node.

