### PR TITLE
agent: move the iptables bridge forwarding disable to agent register

### DIFF
--- a/pkg/controller/agent/vlanconfig/controller.go
+++ b/pkg/controller/agent/vlanconfig/controller.go
@@ -62,6 +62,10 @@ func Register(ctx context.Context, management *config.Management) error {
 		cnCache:    cns.Cache(),
 	}
 
+	if err := handler.initialize(); err != nil {
+		return fmt.Errorf("initialize error: %w", err)
+	}
+
 	vcs.OnChange(ctx, ControllerName, handler.OnChange)
 	vcs.OnRemove(ctx, ControllerName, handler.OnRemove)
 
@@ -119,6 +123,13 @@ func (h Handler) OnRemove(_ string, vc *networkv1.VlanConfig) (*networkv1.VlanCo
 	}
 
 	return vc, nil
+}
+
+func (h Handler) initialize() error {
+	if err := iface.DisableBridgeNF(); err != nil {
+		return fmt.Errorf("disable net.bridge.bridge-nf-call-iptables failed, error: %v", err)
+	}
+	return nil
 }
 
 // MatchNode will also return the executed vlanconfig with the same clusterNetwork on this node if existing

--- a/pkg/network/vlan/vlan.go
+++ b/pkg/network/vlan/vlan.go
@@ -142,9 +142,3 @@ func (v *Vlan) Bridge() *iface.Bridge {
 func (v *Vlan) Uplink() *iface.Link {
 	return v.uplink
 }
-
-func init() {
-	if err := iface.DisableBridgeNF(); err != nil {
-		klog.Fatalf("disable net.bridge.bridge-nf-call-iptables failed, error: %v", err)
-	}
-}


### PR DESCRIPTION
The DisableBridgeNF() placed in init() would cause phantom error message while restart/kill the network-manager pod. Move it to agent register to prevent the unexpected invoke.

Fixes: 652162909d48 ("Disable iptables bridge forwarding on initializatio")

**Problem:**
https://github.com/harvester/harvester/issues/6747

**Solution:**
Move the DisableBridgeNF() to agent register to prevent the unexpected invoke.

**Related Issue:**

**Test plan:**
1. Manually restarting the `harvester-network-controller-manager` deployment or simply killing off the pod
2. check if there's the error message `disable net.bridge.bridge-nf-call-iptables failed, error: open /proc/sys/net/bridge/bridge-nf-call-iptables: read-only file system`
3.   

