### PR TITLE
Make the build consistent across archs for Go to correctly report the package path inside the binary

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -8,7 +8,7 @@ cd $(dirname $0)/..
 mkdir -p bin
 
 for arch in "amd64" "arm64"; do
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-controller-"$arch" cmd/network-controller/main.go
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-helper-"$arch" cmd/network-helper/main.go
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-webhook-"$arch" cmd/webhook/main.go
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-controller-"$arch" ./cmd/network-controller
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-helper-"$arch" ./cmd/network-helper
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-webhook-"$arch" ./cmd/webhook
 done


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The build process is passing directly the `main.go` file for the build. According to Go's spec, this results in Go not properly identifying the package and module path and then marking the compiled binary as `command-line-arguments`.

Before:

```
> go version -m main
main: go1.22.9
	path	command-line-arguments
```

Now:

```
> go version -m webhook 
webhook: go1.22.9
	path	github.com/harvester/harvester-network-controller/cmd/webhook
	mod	github.com/harvester/harvester-network-controller	(devel)
```

Although this is a minor thing and that doesn't affect the binary itself, it actually blocks security scanners, for example Trivy, from correctly matching the binary (and its path/module origin) with a VEX entry.

This was identified internally when a false-positive vulnerability that was supposed to be suppressed was still being reported in the scanning reports.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Only pass the directory that contains the Go file to build, not the file itself.

**Related Issue:**
N/A

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
See above.