### PR TITLE
[v0.4] Make the build consistent across archs for Go to correctly report the package path inside the binary

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -8,7 +8,7 @@ cd $(dirname $0)/..
 mkdir -p bin
 
 for arch in "amd64" "arm64"; do
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-controller-"$arch" cmd/network-controller/main.go
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-helper-"$arch" cmd/network-helper/main.go
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-webhook-"$arch" cmd/webhook/main.go
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-controller-"$arch" ./cmd/network-controller
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-helper-"$arch" ./cmd/network-helper
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-network-webhook-"$arch" ./cmd/webhook
 done


### PR DESCRIPTION
Backport of https://github.com/harvester/network-controller-harvester/pull/127.