### PR TITLE
Use VMCache instead of VMICache to judge if the NAD is in use

### DIFF
--- a/pkg/webhook/nad/validator.go
+++ b/pkg/webhook/nad/validator.go
@@ -25,13 +25,16 @@ const (
 type Validator struct {
 	admission.DefaultValidator
 	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache
+	vmCache  ctlkubevirtv1.VirtualMachineCache
 }
 
 var _ admission.Validator = &Validator{}
 
-func NewNadValidator(vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) *Validator {
+func NewNadValidator(vmiCache ctlkubevirtv1.VirtualMachineInstanceCache,
+	vmCache ctlkubevirtv1.VirtualMachineCache) *Validator {
 	return &Validator{
 		vmiCache: vmiCache,
+		vmCache:  vmCache,
 	}
 }
 
@@ -126,7 +129,7 @@ func (v *Validator) checkRoute(config string) error {
 }
 
 func (v *Validator) checkVmi(nad *cniv1.NetworkAttachmentDefinition) error {
-	vmiGetter := utils.VmiGetter{VmiCache: v.vmiCache}
+	vmiGetter := utils.VmiGetter{VmiCache: v.vmiCache, VMCache: v.vmCache}
 	vmis, err := vmiGetter.WhoUseNad(nad, nil)
 	if err != nil {
 		return err
@@ -135,7 +138,7 @@ func (v *Validator) checkVmi(nad *cniv1.NetworkAttachmentDefinition) error {
 	if len(vmis) > 0 {
 		vmiNameList := make([]string, 0, len(vmis))
 		for _, vmi := range vmis {
-			vmiNameList = append(vmiNameList, vmi.Namespace+"/"+vmi.Name)
+			vmiNameList = append(vmiNameList, vmi)
 		}
 		return fmt.Errorf("it's still used by VM(s) %s which must be stopped at first", strings.Join(vmiNameList, ", "))
 	}

--- a/pkg/webhook/vlanconfig/validator.go
+++ b/pkg/webhook/vlanconfig/validator.go
@@ -14,7 +14,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"github.com/harvester/harvester/pkg/util"
 
@@ -218,20 +217,13 @@ func (v *Validator) checkVmi(vc *networkv1.VlanConfig, nodes mapset.Set[string])
 	}
 
 	vmiGetter := utils.VmiGetter{VmiCache: v.vmiCache}
-	vmis := make([]*kubevirtv1.VirtualMachineInstance, 0)
+	vmiStrList := make([]string, 0)
 	for _, nad := range nads {
 		vmisTemp, err := vmiGetter.WhoUseNad(nad, nodes)
 		if err != nil {
 			return err
 		}
-		vmis = append(vmis, vmisTemp...)
-	}
-
-	if len(vmis) > 0 {
-		vmiStrList := make([]string, len(vmis))
-		for i, vmi := range vmis {
-			vmiStrList[i] = vmi.Namespace + "/" + vmi.Name
-		}
+		vmiStrList = append(vmiStrList, vmisTemp...)
 
 		return fmt.Errorf("it's blocked by VM(s) %s which must be stopped at first", strings.Join(vmiStrList, ", "))
 	}


### PR DESCRIPTION
The VMI status will be none if the VM is turned off from the GUI. The VMI information can't not be relied to make sure if particular NAD is attched to any VM or not. Use VMCache instead to prevent from deleting the NAD if the VM is turned off.

**Problem:**
Fail to delete an Off VM if its network was deleted. The VM network can be deleted if the attached VM is `off`. It will be a problem if user try to turn the VM back to on.

**Solution:**
Do not allow VM network remove if the VM still exists, even it is OFF.

**Related Issue:**
https://github.com/harvester/harvester/issues/6961

**Test plan:**
1. Create a VM network
2. Create a VM and attached to the created VM network
3. Turn the VM from `Running` to `Off`.
4. Remove the VM network. Should not allow.

