### PR TITLE
Use VMCache instead of VMICache to judge if the NAD is in use

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -118,8 +118,8 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 
 	if err := webhookServer.RegisterValidators(
 		clusternetwork.NewCnValidator(c.vcCache),
-		nad.NewNadValidator(c.vmiCache),
-		vlanconfig.NewVlanConfigValidator(c.nadCache, c.vcCache, c.vsCache, c.vmiCache),
+		nad.NewNadValidator(c.vmiCache, c.vmCache),
+		vlanconfig.NewVlanConfigValidator(c.nadCache, c.vcCache, c.vsCache, c.vmiCache, c.vmCache),
 	); err != nil {
 		return fmt.Errorf("failed to register validators: %v", err)
 	}
@@ -135,6 +135,7 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 
 type caches struct {
 	nadCache  ctlcniv1.NetworkAttachmentDefinitionCache
+	vmCache   ctlkubevirtv1.VirtualMachineCache
 	vmiCache  ctlkubevirtv1.VirtualMachineInstanceCache
 	vcCache   ctlnetworkv1.VlanConfigCache
 	vsCache   ctlnetworkv1.VlanStatusCache
@@ -155,6 +156,7 @@ func newCaches(ctx context.Context, cfg *rest.Config, threadiness int) (*caches,
 	starters = append(starters, coreFactory)
 	// must declare cache before starting informers
 	c := &caches{
+		vmCache:   kubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 		vmiCache:  kubevirtFactory.Kubevirt().V1().VirtualMachineInstance().Cache(),
 		nadCache:  cniFactory.K8s().V1().NetworkAttachmentDefinition().Cache(),
 		vcCache:   harvesterNetworkFactory.Network().V1beta1().VlanConfig().Cache(),
@@ -164,6 +166,7 @@ func newCaches(ctx context.Context, cfg *rest.Config, threadiness int) (*caches,
 	}
 	// Indexer must be added before starting the informer, otherwise panic `cannot add indexers to running index` happens
 	c.vmiCache.AddIndexer(indexeres.VMByNetworkIndex, vmiByNetwork)
+	c.vmCache.AddIndexer(indexeres.VMByNetworkIndex, indexeres.VMByNetwork)
 
 	if err := start.All(ctx, threadiness, starters...); err != nil {
 		return nil, err


### PR DESCRIPTION
The VMI status will be none if the VM is turned off from the GUI. The VMI information can't not be relied to make sure if particular NAD is attched to any VM or not. Use VMCache instead to prevent from deleting the NAD if the VM is turned off.

**Problem:**
Fail to delete an Off VM if its network was deleted. The VM network can be deleted if the attached VM is off. It will be a problem if user try to turn the VM back to on.

**Solution:**
Do not allow VM network removing if the VM still exists, even it is OFF.

**Related Issue:**
https://github.com/harvester/harvester/issues/6961

**Test plan:**
1. Create a VM network
2. Create a VM and attached to the created VM network
3. Turn the VM from Running to Off.
4. Remove the VM network. Should not be allowed.
