### PR TITLE
chore: update copyright year to 2025 and change Rancher Labs to SUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ helm install harvester-network-controller harvester/harvester-network-controll
 ```
 
 ## License
-Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)
+Copyright (c) 2025 [SUSE, LLC.](https://www.suse.com/)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Summary
chore: update copyright year to 2025 and change Rancher Labs to SUSE

### PR Checklists
* Do we need to backport this PR change to the [Harvester Dashboard](https://github.com/harvester/dashboard)?

  * [ ]  Yes, the relevant PR is at:
* Are backend engineers aware of UI changes?

  * [ ]  Yes, the backend owner is:

### Related Issue
### Test screenshot/video
### Extra technical notes summary