### PR TITLE
Handle bridge vlan deletion during NAD update

### DIFF
--- a/pkg/controller/agent/nad/controller.go
+++ b/pkg/controller/agent/nad/controller.go
@@ -119,7 +119,7 @@ func (h Handler) existDuplicateNad(vlanIDStr, cn string) (bool, error) {
 		return false, err
 	}
 
-	return len(nads) > 1, nil
+	return len(nads) > 0, nil
 }
 
 func (h Handler) removeLocalArea(clusternetwork string, localArea *vlan.LocalArea) error {
@@ -141,8 +141,11 @@ func (h Handler) removeLocalArea(clusternetwork string, localArea *vlan.LocalAre
 }
 
 func (h Handler) removeOutdatedLocalArea(nad *nadv1.NetworkAttachmentDefinition) (*nadv1.NetworkAttachmentDefinition, error) {
-	if nad.Labels[utils.KeyLastNetworkType] != string(utils.L2VlanNetwork) ||
-		nad.Labels[utils.KeyLastClusterNetworkLabel] == "" && nad.Labels[utils.KeyLastVlanLabel] == "" {
+	//Skip removelocalArea only
+	//when LastNetworkType=untagged
+	//when LastNetworkType="" and there is no change in cluster network or vlan id
+	if nad.Labels[utils.KeyLastNetworkType] == string(utils.UntaggedNetwork) ||
+		nad.Labels[utils.KeyLastNetworkType] == "" && nad.Labels[utils.KeyLastClusterNetworkLabel] == "" && nad.Labels[utils.KeyLastVlanLabel] == "" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
**Problem:**
When updating the VM VLAN Network for fields like cluster network or vlan, the corresponding vlan is added to the new cluster network, but not removed from old cluster network.

a.Network controller skips deletion of vlan from bridge (removeLocalArea) when LastKeyNetworkType is empty
b.bug in checking the length of existing nad count in nad cache

**Solution:**
LastKeyNetworkType could be empty but there could be a cluster network/vlan id update.

**Related Issue:**
https://github.com/harvester/harvester/issues/7676

**Test plan:**

case 1:
a.create cluster1 ->vlanconfig1 on node1
b.create cluster2 -> vlanconfig2 on node2
c.create NAD1 with vlan 2013 in cluster1
d.create NAD2 with vlan 2013 in cluster2

Node 1: output of "bridge vlan show"
should show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2013 vlan part of cluster-2

e.Update the NAD2 from cluster2 to cluster1

Expected Behavior:
Node 1: output of "bridge vlan show"
should show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should not show 2013 vlan part of cluster-2

as vlan 2013 is not part of cluster-2 anymore.

case 2:
a.Update NAD2 to cluster 2 again

Node 1: output of "bridge vlan show"
should show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2013 vlan part of cluster-2

case 3:
a.Update the vlan id of NAD1 to 2012

Node 1: output of "bridge vlan show"
should show 2012 vlan part of cluster-1
should not show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2013 vlan part of cluster-2

case 4:
a.Update the vlan id of NAD2 to 2012

Node 1: output of "bridge vlan show"
should show 2012 vlan part of cluster-1
should not show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2012 vlan part of cluster-2
should not show 2013 vlan part of cluster-2

case 5:
a.Update the vlan id of NAD1 back to 2013
b.Update the vlan id of NAD2 back to 2013

Node 1: output of "bridge vlan show"
should show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2013 vlan part of cluster-2