### PR TITLE
Remove mgmt cluster check during bridge vlan add/del

### DIFF
--- a/pkg/controller/agent/nad/controller.go
+++ b/pkg/controller/agent/nad/controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/harvester/harvester-network-controller/pkg/config"
+	"github.com/harvester/harvester-network-controller/pkg/network/iface"
 	"github.com/harvester/harvester-network-controller/pkg/network/vlan"
 	"github.com/harvester/harvester-network-controller/pkg/utils"
 )
@@ -22,6 +23,7 @@ const ControllerName = "harvester-network-nad-controller"
 type Handler struct {
 	nadCache  ctlcniv1.NetworkAttachmentDefinitionCache
 	nadClient ctlcniv1.NetworkAttachmentDefinitionClient
+	mgmtVlan  int
 }
 
 func Register(ctx context.Context, management *config.Management) error {
@@ -31,6 +33,12 @@ func Register(ctx context.Context, management *config.Management) error {
 		nadCache:  nad.Cache(),
 		nadClient: nad,
 	}
+
+	vlanID, err := GetMgmtVlan()
+	if err != nil {
+		return fmt.Errorf("get mgmt vlan failed")
+	}
+	handler.mgmtVlan = vlanID
 
 	nad.OnChange(ctx, ControllerName, handler.OnChange)
 	nad.OnRemove(ctx, ControllerName, handler.OnRemove)
@@ -123,6 +131,11 @@ func (h Handler) existDuplicateNad(vlanIDStr, cn string) (bool, error) {
 }
 
 func (h Handler) removeLocalArea(clusternetwork string, localArea *vlan.LocalArea) error {
+	//do not delete vlan id configured for mgmt-br from any user operations
+	if clusternetwork == utils.ManagementClusterNetworkName && localArea.Vid == uint16(h.mgmtVlan) {
+		return nil
+	}
+
 	// Skip the case that there are nads with the same cluster network and VLAN id.
 	if ok, err := h.existDuplicateNad(strconv.Itoa(int(localArea.Vid)), clusternetwork); err != nil {
 		return err
@@ -188,4 +201,13 @@ func GetLocalArea(vlanIDStr, routeConf string) (*vlan.LocalArea, error) {
 		Vid:  uint16(vlanID),
 		Cidr: layer3NetworkConf.CIDR,
 	}, nil
+}
+
+func GetMgmtVlan() (vlanID int, err error) {
+	vlanID, err = iface.GetMgmtVlan()
+	if err != nil {
+		return vlanID, fmt.Errorf("failed to get vlan id from mgmt-br %d", vlanID)
+	}
+
+	return vlanID, nil
 }

--- a/pkg/network/iface/link.go
+++ b/pkg/network/iface/link.go
@@ -2,6 +2,7 @@ package iface
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -206,4 +207,24 @@ func (l *Link) Remove() error {
 	}
 
 	return netlink.LinkDel(l)
+}
+
+func GetMgmtVlan() (vlanID int, err error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return vlanID, err
+	}
+
+	for _, link := range links {
+		if !strings.Contains(link.Attrs().Name, "mgmt-br.") {
+			continue
+		}
+
+		result := strings.Split(link.Attrs().Name, ".")
+		if vlanID, err = strconv.Atoi(result[1]); err != nil {
+			return vlanID, err
+		}
+	}
+
+	return vlanID, nil
 }

--- a/pkg/network/vlan/vlan.go
+++ b/pkg/network/vlan/vlan.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/klog"
 
 	"github.com/harvester/harvester-network-controller/pkg/network/iface"
-	"github.com/harvester/harvester-network-controller/pkg/utils"
 )
 
 type Vlan struct {
@@ -104,10 +103,8 @@ func (v *Vlan) AddLocalArea(la *LocalArea) error {
 		return fmt.Errorf("bridge %s hasn't attached an uplink", v.bridge.Name)
 	}
 
-	if v.name != utils.ManagementClusterNetworkName {
-		if err := v.uplink.AddBridgeVlan(la.Vid); err != nil {
-			return fmt.Errorf("add bridge vlanconfig %d failed, error: %w", la.Vid, err)
-		}
+	if err := v.uplink.AddBridgeVlan(la.Vid); err != nil {
+		return fmt.Errorf("add bridge vlanconfig %d failed, error: %w", la.Vid, err)
 	}
 
 	if err := iface.EnsureRouteViaGateway(la.Cidr); err != nil {
@@ -122,10 +119,8 @@ func (v *Vlan) RemoveLocalArea(la *LocalArea) error {
 		return fmt.Errorf("bridge %s hasn't attached an uplink", v.bridge.Name)
 	}
 
-	if v.name != utils.ManagementClusterNetworkName {
-		if err := v.uplink.DelBridgeVlan(la.Vid); err != nil {
-			return fmt.Errorf("remove bridge vlanconfig %d failed, error: %w", la.Vid, err)
-		}
+	if err := v.uplink.DelBridgeVlan(la.Vid); err != nil {
+		return fmt.Errorf("remove bridge vlanconfig %d failed, error: %w", la.Vid, err)
 	}
 
 	if err := iface.DeleteRouteViaGateway(la.Cidr); err != nil {


### PR DESCRIPTION
**Problem:**
During Harvester installation, the system attempts to add all VLAN IDs to the management bond/bridge. With Mellanox ConnectX-6 NICs (which support 512 hardware-offloaded VLANs and have hardware VLAN offloading enabled by default), this causes boot log warnings and prevents management VLAN 2301 from being added to the hardware offloaded VLAN list.

**Solution:**
dynamically add vlans to mgmt cluster network whenever user creates and updates the nad with mgmt cluster network
This will add vlan associated with that nad to mgmt-bo bridge in linux.

**Related Issue:**
https://github.com/harvester/harvester/issues/7650

**Test plan:**
1.Create NAD with vlan-id and attach it to cluster network mgmt
2.verify if bridge vlan show lists the vlan in the mgmt-bo
3.verify traffic between VMs connected over the vlan on mgmt-bo and its successful
4.Delete NAD with vlan-id from mgmt cluster
5.Verify if bridge vlan show removed vlan-id from mgmt-bo

This PR should be merged along with https://github.com/harvester/harvester-installer/pull/1005
