### PR TITLE
Fix scan.yaml to use ubuntu-latest OS

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Github refused to run related job as the required Ubuntu OS is EOL.

https://github.com/harvester/network-controller-harvester/actions/runs/13657731201

```
[Build](https://github.com/harvester/network-controller-harvester/actions/runs/13657731201/job/38181087593)
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101

Build
GitHub Actions has encountered an internal error when running your job.
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Use latest OS

**Related Issue:**
https://github.com/harvester/harvester/issues/4355

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

All PRs should run this job successfully.

Scan.yaml runs successfully.
https://github.com/harvester/network-controller-harvester/actions/runs/13657810131

This PR is a cherry-pick from PR https://github.com/harvester/network-controller-harvester/pull/149