### PR TITLE
Handle Bridge vlan deletion during nad update

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/pkg/controller/agent/nad/controller.go
+++ b/pkg/controller/agent/nad/controller.go
@@ -141,8 +141,11 @@ func (h Handler) removeLocalArea(clusternetwork string, localArea *vlan.LocalAre
 }
 
 func (h Handler) removeOutdatedLocalArea(nad *nadv1.NetworkAttachmentDefinition) (*nadv1.NetworkAttachmentDefinition, error) {
-	if nad.Labels[utils.KeyLastNetworkType] != string(utils.L2VlanNetwork) ||
-		nad.Labels[utils.KeyLastClusterNetworkLabel] == "" && nad.Labels[utils.KeyLastVlanLabel] == "" {
+	//Skip removelocalArea only
+	//when LastNetworkType=untagged
+	//when LastNetworkType="" and there is no change in vlan id
+	if nad.Labels[utils.KeyLastNetworkType] == string(utils.UntaggedNetwork) ||
+		nad.Labels[utils.KeyLastNetworkType] == "" && nad.Labels[utils.KeyLastVlanLabel] == "" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
**Problem:**
When updating the VM VLAN Network for fields like vlan, the corresponding vlan is added to the new bridge, but not removed from old bridge.

a.Network controller skips deletion of vlan from bridge (removeLocalArea) when LastKeyNetworkType is empty

**Solution:**
LastKeyNetworkType could be empty but there could be a cluster vlan id update.

PR https://github.com/harvester/network-controller-harvester/pull/149 has bunch of network-controller improvements and webhook checks including "prevention of cluster network updates on a NAD".

**Related Issue:**
https://github.com/harvester/harvester/issues/7676

**Test plan:**
a.create cluster1 ->vlanconfig1 on node1
b.create cluster2 -> vlanconfig2 on node2
c.create NAD1 with vlan 2013 in cluster1
d.create NAD2 with vlan 2013 in cluster2

Node 1: output of "bridge vlan show"
should show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2013 vlan part of cluster-2

case 1:
a.Update the vlan id of NAD1 to 2012

Node 1: output of "bridge vlan show"
should show 2012 vlan part of cluster-1
should not show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2013 vlan part of cluster-2

case 2:
a.Update the vlan id of NAD2 to 2012

Node 1: output of "bridge vlan show"
should show 2012 vlan part of cluster-1
should not show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2012 vlan part of cluster-2
should not show 2013 vlan part of cluster-2

case 5:
a.Update the vlan id of NAD1 back to 2013
b.Update the vlan id of NAD2 back to 2013

Node 1: output of "bridge vlan show"
should show 2013 vlan part of cluster-1

Node 2: output of "bridge vlan show"
should show 2013 vlan part of cluster-2



