### PR TITLE
Add vlans only from associated cluster network during network config change

### DIFF
--- a/pkg/controller/agent/vlanconfig/controller.go
+++ b/pkg/controller/agent/vlanconfig/controller.go
@@ -184,7 +184,7 @@ func (h Handler) setupVLAN(vc *networkv1.VlanConfig) error {
 	var localAreas []*vlan.LocalArea
 	var uplink *iface.Link
 	// get VIDs
-	localAreas, setupErr = h.getLocalAreas()
+	localAreas, setupErr = h.getLocalAreas(vc)
 	if setupErr != nil {
 		goto updateStatus
 	}
@@ -281,8 +281,10 @@ func setUplink(vc *networkv1.VlanConfig) (*iface.Link, error) {
 	return &iface.Link{Link: b}, nil
 }
 
-func (h Handler) getLocalAreas() ([]*vlan.LocalArea, error) {
-	nads, err := h.nadCache.List("", labels.Everything())
+func (h Handler) getLocalAreas(vc *networkv1.VlanConfig) ([]*vlan.LocalArea, error) {
+	nads, err := h.nadCache.List("", labels.Set(map[string]string{
+		utils.KeyClusterNetworkLabel: vc.Spec.ClusterNetwork,
+	}).AsSelector())
 	if err != nil {
 		return nil, fmt.Errorf("list nad failed, error: %v", err)
 	}


### PR DESCRIPTION
**Problem:**
vlans are added from previously created cluster networks during a new network config change
This is due to a bug in network controller which lists nads from all cluster network and tries to add it to new cluster network during vlan config change.Instead the listing of NADs should be done only for the cluster network for which the vlan config changed.

**Solution:**
add only the vlans configured part of the new cluster network whenever network config associated with a cluster network change

**Related Issue:**
https://github.com/harvester/harvester/issues/8067

**Test plan:**
a.Create a VM network tagged with vlan id for example 2012,2013,2014 under mgmt cluster
b.Create another cluster network cluster-1 and add network config
c.Check bridge vlan show

Expected result:
cluster-1-bo 1 PVID Egress Untagged

Actual Result:
cluster-1-bo 1 PVID Egress Untagged
                  2012
                  2013
                  2014