### PR TITLE
Update link attribute processing

### DIFF
--- a/pkg/controller/manager/vlanconfig/controller.go
+++ b/pkg/controller/manager/vlanconfig/controller.go
@@ -91,8 +91,9 @@ func (h Handler) ensureClusterNetwork(vc *networkv1.VlanConfig) error {
 	}
 
 	MTU := utils.DefaultMTU
-	if utils.IsValidMTU(vc.Spec.Uplink.LinkAttrs.MTU) && vc.Spec.Uplink.LinkAttrs.MTU != 0 {
-		MTU = vc.Spec.Uplink.LinkAttrs.MTU
+	vcMtu := utils.GetMTUFromVlanConfig(vc)
+	if utils.IsValidMTU(vcMtu) && vcMtu != 0 {
+		MTU = vcMtu
 	}
 	targetMTU := fmt.Sprintf("%v", MTU)
 

--- a/pkg/network/iface/bridge.go
+++ b/pkg/network/iface/bridge.go
@@ -13,7 +13,7 @@ const (
 	BridgeSuffix         = "-br"
 	bridgeNFCallIptables = "net/bridge/bridge-nf-call-iptables"
 
-	lenOfBridgeSuffix = len(BridgeSuffix)
+	lenOfBridgeSuffix = 3 // lengh of BridgeSuffix
 )
 
 type Bridge struct {

--- a/pkg/utils/mtu.go
+++ b/pkg/utils/mtu.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"fmt"
 	"strconv"
+
+	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
 )
 
 func IsValidMTU(MTU int) bool {
@@ -26,4 +28,13 @@ func GetMTUFromAnnotation(annotation string) (int, error) {
 		return 0, fmt.Errorf("annotation %v value is not in range [0, %v..%v]", annotation, MinMTU, MaxMTU)
 	}
 	return MTU, nil
+}
+
+// caller handlers the return value of 0 which is normally treated as the default MTU
+func GetMTUFromVlanConfig(vc *networkv1.VlanConfig) int {
+	if vc == nil || vc.Spec.Uplink.LinkAttrs == nil {
+		return 0
+	}
+
+	return vc.Spec.Uplink.LinkAttrs.MTU
 }

--- a/pkg/webhook/clusternetwork/validator.go
+++ b/pkg/webhook/clusternetwork/validator.go
@@ -131,14 +131,14 @@ func checkMTUOfNewClusterNetwork(cn *networkv1.ClusterNetwork) error {
 		return nil
 	}
 
-	// for none-mgmt cluster network, this annotation can only be operated by controller
+	// for non-mgmt cluster network, this annotation can only be operated by controller
 	if _, ok := cn.Annotations[utils.KeyUplinkMTU]; ok {
 		return fmt.Errorf("annotation %v can't be added", utils.KeyUplinkMTU)
 	}
 	return nil
 }
 
-// for none-mgmt cluster network
+// for non-mgmt cluster network
 func (c *CnValidator) checkMTUOfUpdatedClusterNetwork(oldCn, newCn *networkv1.ClusterNetwork) error {
 	if oldCn == nil || newCn == nil || newCn.Name == utils.ManagementClusterNetworkName {
 		return nil
@@ -146,8 +146,8 @@ func (c *CnValidator) checkMTUOfUpdatedClusterNetwork(oldCn, newCn *networkv1.Cl
 
 	newMtu := utils.DefaultMTU
 	var err error
-	if mtu, ok := newCn.Annotations[utils.KeyUplinkMTU]; ok {
-		if newMtu, err = utils.GetMTUFromAnnotation(mtu); err != nil {
+	if mtuStr, ok := newCn.Annotations[utils.KeyUplinkMTU]; ok {
+		if newMtu, err = utils.GetMTUFromAnnotation(mtuStr); err != nil {
 			return err
 		}
 	}
@@ -161,8 +161,9 @@ func (c *CnValidator) checkMTUOfUpdatedClusterNetwork(oldCn, newCn *networkv1.Cl
 	}
 
 	for _, vc := range vcs {
-		if !utils.AreEqualMTUs(vc.Spec.Uplink.LinkAttrs.MTU, newMtu) {
-			return fmt.Errorf("clusternetwork has MTU %v, but the vlanconfigs %v has another MTU %v", newMtu, vc.Name, vc.Spec.Uplink.LinkAttrs.MTU)
+		vcMtu := utils.GetMTUFromVlanConfig(vc)
+		if !utils.AreEqualMTUs(vcMtu, newMtu) {
+			return fmt.Errorf("clusternetwork has MTU %v, but the vlanconfigs %v has another MTU %v", newMtu, vc.Name, vcMtu)
 		}
 	}
 
@@ -180,15 +181,15 @@ func (c *CnValidator) checkMTUOfUpdatedMgmtClusterNetwork(oldCn, newCn *networkv
 	// mgmt network, MTU can be updated
 	newMtu := utils.DefaultMTU
 	var err error
-	if mtu, ok := newCn.Annotations[utils.KeyUplinkMTU]; ok {
-		if newMtu, err = utils.GetMTUFromAnnotation(mtu); err != nil {
+	if mtuStr, ok := newCn.Annotations[utils.KeyUplinkMTU]; ok {
+		if newMtu, err = utils.GetMTUFromAnnotation(mtuStr); err != nil {
 			return err
 		}
 	}
 
 	oldMtu := utils.DefaultMTU
-	if mtu, ok := oldCn.Annotations[utils.KeyUplinkMTU]; ok {
-		if oldMtu, err = utils.GetMTUFromAnnotation(mtu); err != nil {
+	if mtuStr, ok := oldCn.Annotations[utils.KeyUplinkMTU]; ok {
+		if oldMtu, err = utils.GetMTUFromAnnotation(mtuStr); err != nil {
 			return err
 		}
 	}

--- a/pkg/webhook/nad/validator.go
+++ b/pkg/webhook/nad/validator.go
@@ -217,11 +217,15 @@ func (v *Validator) checkNadConfig(nadConf *utils.NetConf, nad *cniv1.NetworkAtt
 	getMtu := false
 
 	// get MTU from clusternetwork
-	if lbMTU := cn.Annotations[utils.KeyUplinkMTU]; lbMTU != "" {
-		if mtu, err := utils.GetMTUFromAnnotation(lbMTU); err == nil {
-			targetMTU = mtu
-			getMtu = true
+	if mtuStr, ok := cn.Annotations[utils.KeyUplinkMTU]; ok {
+		mtu, err := utils.GetMTUFromAnnotation(mtuStr)
+		if err != nil {
+			return fmt.Errorf("nad's host cluster network %v has invalid MTU annotation %v/%v %w", cn.Name, utils.KeyUplinkMTU, mtuStr, err)
 		}
+		if mtu != 0 {
+			targetMTU = mtu
+		}
+		getMtu = true
 	}
 
 	// get MTU value from vlanconfig
@@ -233,9 +237,12 @@ func (v *Validator) checkNadConfig(nadConf *utils.NetConf, nad *cniv1.NetworkAtt
 			return err
 		}
 
-		// if there is no vlanconfig, use default
-		if len(vcs) != 0 && utils.IsValidMTU(vcs[0].Spec.Uplink.LinkAttrs.MTU) {
-			targetMTU = vcs[0].Spec.Uplink.LinkAttrs.MTU
+		// if there is no vlanconfig, use default; in other case, use the first one
+		if len(vcs) != 0 {
+			mtu := utils.GetMTUFromVlanConfig(vcs[0])
+			if utils.IsValidMTU(mtu) && mtu != 0 {
+				targetMTU = mtu
+			}
 		}
 	}
 

--- a/pkg/webhook/nad/validator_test.go
+++ b/pkg/webhook/nad/validator_test.go
@@ -91,6 +91,29 @@ func TestCreateNAD(t *testing.T) {
 			},
 		},
 		{
+			name:      "NAD can't be created as it's config is an invalid JSON string",
+			returnErr: true,
+			errKey:    "unmarshal config",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNadName,
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: "test-cn"},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					// config is invalid
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"bridgebridge\",\"promiscMode\":true,\"vlan\":300,\"ipam\":{}}",
+				},
+			},
+		},
+		{
 			name:      "NAD can't be created as it's label does not match bridge name",
 			returnErr: true,
 			errKey:    "does not match",
@@ -266,6 +289,28 @@ func TestCreateNAD(t *testing.T) {
 			},
 		},
 		{
+			name:      "NAD can't be created as it has empty bridge name",
+			returnErr: true,
+			errKey:    "the suffix of the brName",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNadName,
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"promiscMode\":true,\"vlan\":300,\"ipam\":{}}",
+				},
+			},
+		},
+		{
 			name:      "NAD can't be created as has invalid bridge suffix",
 			returnErr: true,
 			errKey:    "the suffix of the brName",
@@ -283,7 +328,29 @@ func TestCreateNAD(t *testing.T) {
 					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
 				},
 				Spec: cniv1.NetworkAttachmentDefinitionSpec{
-					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"suffix-br-\":\"a\",\"promiscMode\":true,\"vlan\":300,\"ipam\":{}}",
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"bridge\":\"suffix-br-\",\"promiscMode\":true,\"vlan\":300,\"ipam\":{}}",
+				},
+			},
+		},
+		{
+			name:      "NAD can't be created as the host cluster network has invalid mtu annotation",
+			returnErr: true,
+			errKey:    "has invalid MTU annotation",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{utils.KeyUplinkMTU: "15000"},
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNadName,
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":300,\"ipam\":{}}",
 				},
 			},
 		},

--- a/pkg/webhook/vlanconfig/validator.go
+++ b/pkg/webhook/vlanconfig/validator.go
@@ -251,8 +251,9 @@ func getMatchNodes(vc *networkv1.VlanConfig) (mapset.Set[string], error) {
 
 func (v *Validator) validateMTU(current *networkv1.VlanConfig) error {
 	// MTU can be 0, it means user does not input and the default value is used
-	if !utils.IsValidMTU(current.Spec.Uplink.LinkAttrs.MTU) {
-		return fmt.Errorf("the MTU %v is out of range [0, %v..%v]", current.Spec.Uplink.LinkAttrs.MTU, utils.MinMTU, utils.MaxMTU)
+	mtu := utils.GetMTUFromVlanConfig(current)
+	if !utils.IsValidMTU(mtu) {
+		return fmt.Errorf("the MTU %v is out of range [0, %v..%v]", mtu, utils.MinMTU, utils.MaxMTU)
 	}
 
 	// ensure all vlanconfigs on one clusternetwork have the same MTU
@@ -267,8 +268,9 @@ func (v *Validator) validateMTU(current *networkv1.VlanConfig) error {
 		if vc.Name == current.Name {
 			continue
 		}
-		if !utils.AreEqualMTUs(current.Spec.Uplink.LinkAttrs.MTU, vc.Spec.Uplink.LinkAttrs.MTU) {
-			return fmt.Errorf("the vlanconfig %s MTU %v is different with another vlanconfig %s MTU %v, all vlanconfigs on one clusternetwork need to have same MTU", current.Name, current.Spec.Uplink.LinkAttrs.MTU, vc.Name, vc.Spec.Uplink.LinkAttrs.MTU)
+		vcMtu := utils.GetMTUFromVlanConfig(vc)
+		if !utils.AreEqualMTUs(mtu, vcMtu) {
+			return fmt.Errorf("the vlanconfig %s MTU %v is different with another vlanconfig %s MTU %v, all vlanconfigs on one clusternetwork need to have same MTU", current.Name, mtu, vc.Name, vcMtu)
 		}
 	}
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The empty `linkAttributes` caused panic.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Update the process of accessing `linkAttributes`, avoid panic
2. Add test code to cover the cases.

**Related Issue:**

https://github.com/harvester/harvester/issues/8589

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. create a second clusternetwork `cn2`
3.1 create a vlanconfig with empty `linkAttributes` like below
```
apiVersion: network.harvesterhci.io/v1beta1
kind: VlanConfig
metadata:
  name: nc4
spec:
  clusterNetwork: cn2
  uplink:
    bondOptions:
      miimon: -1
      mode: active-backup
    nics:
    - ens8
```
2.2 create a vlanconfig from Harvester UI, then edit this vlanconfig to remove the whole `linkAttributes`
```
spec:
  clusterNetwork: cn2
  uplink:
    bondOptions:
      miimon: -1
      mode: active-backup
    linkAttributes:  // remove
      mtu: 1600  // remove
      txQLen: -1 // remove
```

4. both should be successful


All the above cases have been tested with this PR.