### PR TITLE
skip validator checks for default ovn cluster subnets

### DIFF
--- a/pkg/utils/subnet.go
+++ b/pkg/utils/subnet.go
@@ -1,0 +1,21 @@
+package utils
+
+import "fmt"
+
+const (
+	joinSubnet       = "join"
+	ovnDefaultSubnet = "ovn-default"
+)
+
+func IsReservedSubnet(subnetName string, provider string) (bool, error) {
+	//join and ovn-default are default subnets in ovn cluster
+	switch subnetName {
+	case joinSubnet, ovnDefaultSubnet:
+		if provider != ovnProvider {
+			return true, fmt.Errorf("not a default subnet %s as provider is %s", subnetName, provider)
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/pkg/webhook/subnet/validator_test.go
+++ b/pkg/webhook/subnet/validator_test.go
@@ -60,6 +60,45 @@ func TestCreateSubnet(t *testing.T) {
 			},
 		},
 		{
+			name:      "default subnet join can be created",
+			returnErr: false,
+			errKey:    "",
+			newSubnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "join",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Provider: "ovn",
+				},
+			},
+		},
+		{
+			name:      "default subnet ovn-default can be created",
+			returnErr: false,
+			errKey:    "",
+			newSubnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ovn-default",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Provider: "ovn",
+				},
+			},
+		},
+		{
+			name:      "user created subnet with default subnets name,should fail",
+			returnErr: true,
+			errKey:    "not a default subnet",
+			newSubnet: &kubeovnv1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ovn-default",
+				},
+				Spec: kubeovnv1.SubnetSpec{
+					Provider: "vswitch1.default.ovn",
+				},
+			},
+		},
+		{
 			name:      "provider is empty for subnet,return error",
 			returnErr: true,
 			errKey:    "provider is empty",


### PR DESCRIPTION
**Problem:**
currently "join" and "ovn-default" subnets are ovn cluster default subnets created once the kube-ovn add-on is enabled.
Since network-controller is already running and kube-ovn add-on is enabled later, creation of these subnets happen and network controller webhook validates it for provider length expecting type "nadname.namespace.ovn" but these subnets have a default provider type "ovn". 

**Solution:**
skip subnet validations for default subnets "join" and "ovn-default"

**Related Issue:**
https://github.com/harvester/harvester/issues/8698

**Test plan:**
1.Install v1.6-rc2
2.Enable kube-ovn add-on
3.Kubectl get pods -n kube-system | grep ovn
All ovn related pods must be running successfully
4.harvester-network-webhook pods should not throw any error "invalid provider length 1 for provider ovn"

