### PR TITLE
Fix the mgmt bridge interface format

### DIFF
--- a/pkg/network/iface/link.go
+++ b/pkg/network/iface/link.go
@@ -215,7 +215,7 @@ func GetMgmtVlan() (vlanID int, err error) {
 		return vlanID, err
 	}
 
-	mgmtBrIntf := utils.ManagementClusterNetworkName + "-" + BridgeSuffix + "."
+	mgmtBrIntf := utils.ManagementClusterNetworkName + BridgeSuffix + "."
 	for _, link := range links {
 		if !strings.HasPrefix(link.Attrs().Name, mgmtBrIntf) {
 			continue


### PR DESCRIPTION
**Problem:**
Deleting a VM Network on mgmt cluster removes the mgmt vlan causing Harvester node to lose connectivity

**Solution:**
Fix the wrong format to derive the mgmt-br.<vlan-id> interface from Harvester host interfaces 

**Related Issue:**
https://github.com/harvester/harvester/issues/8953

**Test plan:**
1.Mgmt vlan interface is part of vlan 2021 (mgm-br.2021)
2.Create a vlan vm network with tag 2021 and cluster network "mgmt"
3.Delete the vlan VM Network created created in step 2

Expected Behavior:
1VM Network created on vlan 2021 mgmt cluster must be removed for user but 2021 should not be removed from "bridge vlan ..." of mgmt interface on Harvester host.

