### PR TITLE
Fix log level setting

### DIFF
--- a/cmd/network-controller/main.go
+++ b/cmd/network-controller/main.go
@@ -28,7 +28,7 @@ var (
 )
 
 func main() {
-	logLevel := "info"
+	logLevel := utils.GetDefaultLogLevel()
 	app := cli.NewApp()
 	app.Name = name
 	app.Version = VERSION
@@ -37,8 +37,8 @@ func main() {
 		cli.StringFlag{
 			Name:        "loglevel",
 			Usage:       "Specify log level",
-			EnvVar:      "LOGLEVEL",
-			Value:       "info",
+			EnvVar:      utils.EnvLogLevel,
+			Value:       utils.GetDefaultLogLevel(),
 			Destination: &logLevel,
 		},
 		cli.StringFlag{
@@ -86,22 +86,30 @@ func main() {
 
 	app.Commands = []cli.Command{
 		{
-			Name:   "manager",
-			Usage:  "Run manager",
-			Action: managerRun,
-			Flags:  commonFlags,
+			Name:  "manager",
+			Usage: "Run manager",
+			Action: func(ctx *cli.Context) {
+				utils.SetLogLevel(logLevel)
+				if err := managerRun(ctx); err != nil {
+					logrus.Fatalf("run manager failed: %v", err)
+				}
+			},
+			Flags: commonFlags,
 		},
 		{
-			Name:   "agent",
-			Usage:  "Run agent",
-			Action: agentRun,
-			Flags:  commonFlags,
+			Name:  "agent",
+			Usage: "Run agent",
+			Action: func(ctx *cli.Context) {
+				utils.SetLogLevel(logLevel)
+				if err := agentRun(ctx); err != nil {
+					logrus.Fatalf("run agent failed: %v", err)
+				}
+			},
+			Flags: commonFlags,
 		},
 	}
 
 	logrus.Infof("Starting %v version %v", app.Name, app.Version)
-
-	utils.SetLogLevel(logLevel)
 
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)

--- a/cmd/network-helper/main.go
+++ b/cmd/network-helper/main.go
@@ -24,10 +24,18 @@ var (
 )
 
 func main() {
+	logLevel := utils.GetDefaultLogLevel()
 	app := cli.NewApp()
 	app.Name = name
 	app.Usage = "network-helper is to help get the network information through DHCP protocol from the pod within the VLAN network"
 	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "loglevel",
+			Usage:       "Specify log level",
+			EnvVar:      utils.EnvLogLevel,
+			Value:       utils.GetDefaultLogLevel(),
+			Destination: &logLevel,
+		},
 		cli.StringFlag{
 			Name:   "kubeconfig, k",
 			EnvVar: "KUBECONFIG",
@@ -55,6 +63,7 @@ func main() {
 		},
 	}
 	app.Action = func(c *cli.Context) {
+		utils.SetLogLevel(logLevel)
 		if err := run(c); err != nil {
 			panic(err)
 		}

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -52,14 +52,14 @@ var (
 
 func main() {
 	var options config.Options
-	logLevel := "info"
+	logLevel := utils.GetDefaultLogLevel()
 
 	flags := []cli.Flag{
 		cli.StringFlag{
 			Name:        "loglevel",
 			Usage:       "Specify log level",
-			EnvVar:      "LOGLEVEL",
-			Value:       "info",
+			EnvVar:      utils.EnvLogLevel,
+			Value:       utils.GetDefaultLogLevel(),
 			Destination: &logLevel,
 		},
 		cli.IntFlag{

--- a/pkg/controller/manager/nad/controller.go
+++ b/pkg/controller/manager/nad/controller.go
@@ -496,25 +496,38 @@ func constructJob(cur *batchv1.Job, namespace, image string, nad *cniv1.NetworkA
 	}
 	job.Spec.Template.ObjectMeta.Annotations[cniv1.NetworkAttachmentAnnot] = selectedNetworks
 
+	getEnv := func() []corev1.EnvVar {
+		env := []corev1.EnvVar{
+			{
+				Name: JobEnvNadNetwork,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.annotations['%s']", cniv1.NetworkAttachmentAnnot),
+					},
+				},
+			},
+			{
+				Name:  JobEnvDHCPServer,
+				Value: l3netconf.GetDHCPServerIPAddr(),
+			},
+		}
+		// set LOGLEVEL env when it is not the default value
+		if !utils.IsDefaultLogLevel() {
+			env = append(env, corev1.EnvVar{
+				Name:  utils.EnvLogLevel,
+				Value: utils.GetLogLevel(), // inherit the current log level
+			})
+		}
+
+		return env
+	}
+
 	// podSpec
 	job.Spec.Template.Spec.Containers = []corev1.Container{
 		{
-			Name:  jobContainerName,
-			Image: image,
-			Env: []corev1.EnvVar{
-				{
-					Name: JobEnvNadNetwork,
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: fmt.Sprintf("metadata.annotations['%s']", cniv1.NetworkAttachmentAnnot),
-						},
-					},
-				},
-				{
-					Name:  JobEnvDHCPServer,
-					Value: l3netconf.GetDHCPServerIPAddr(),
-				},
-			},
+			Name:            jobContainerName,
+			Image:           image,
+			Env:             getEnv(),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 		},
 	}

--- a/pkg/controller/manager/nad/controller.go
+++ b/pkg/controller/manager/nad/controller.go
@@ -511,11 +511,12 @@ func constructJob(cur *batchv1.Job, namespace, image string, nad *cniv1.NetworkA
 				Value: l3netconf.GetDHCPServerIPAddr(),
 			},
 		}
-		// set LOGLEVEL env when it is not the default value
+
+		// Only inject non-default log levels during initialization.
 		if !utils.IsDefaultLogLevel() {
 			env = append(env, corev1.EnvVar{
 				Name:  utils.EnvLogLevel,
-				Value: utils.GetLogLevel(), // inherit the current log level
+				Value: utils.GetLogLevel(),
 			})
 		}
 
@@ -523,14 +524,18 @@ func constructJob(cur *batchv1.Job, namespace, image string, nad *cniv1.NetworkA
 	}
 
 	// podSpec
-	job.Spec.Template.Spec.Containers = []corev1.Container{
-		{
-			Name:            jobContainerName,
-			Image:           image,
-			Env:             getEnv(),
-			ImagePullPolicy: corev1.PullIfNotPresent,
-		},
+	// Job Pod templates are immutable, so existing jobs cannot be updated.
+	if cur == nil {
+		job.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:            jobContainerName,
+				Image:           image,
+				Env:             getEnv(),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+			},
+		}
 	}
+
 	// Add nodeAffinity to prove the job pod is scheduled to the proper node with the specified cluster network
 	job.Spec.Template.Spec.Affinity = &corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -7,4 +7,6 @@ const (
 	defaultNamespace = "default"
 
 	HarvesterSystemNamespaceName = "harvester-system" // don't import harvester/pkg/util to avoid loop importing, define it directly
+
+	EnvLogLevel = "LOGLEVEL"
 )

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -15,3 +15,15 @@ func SetLogLevel(level string) {
 	// set global log level
 	logrus.SetLevel(ll)
 }
+
+func GetLogLevel() string {
+	return logrus.GetLevel().String()
+}
+
+func GetDefaultLogLevel() string {
+	return "info"
+}
+
+func IsDefaultLogLevel() bool {
+	return logrus.GetLevel() == logrus.InfoLevel
+}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

env LOGLEVEL doesn't work on network-controller

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

fix it

**Related Issue:**

https://github.com/harvester/harvester/issues/10250


**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Change the deployment/daemonset env on network-controller, network-controller-manager, the PoD should print the logs per set level.

```
logs -n harvester-system harvester-network-controller-v4x5j
time="2026-03-19T11:03:03Z" level=info msg="Starting harvester-network-controller version 902b5400"
time="2026-03-19T11:03:03Z" level=info msg="Set log level to debug"

...
time="2026-03-19T11:03:11Z" level=debug msg="lm cn2 matches node harv21"

...
logs -n harvester-system harvester-network-controller-manager-dc4d765b4-9t72r | more
time="2026-03-19T11:00:49Z" level=info msg="Starting harvester-network-controller version 902b5400"
time="2026-03-19T11:00:49Z" level=info msg="Set log level to debug"

```