### PR TITLE
Extend VlanConfig protection to cover RWX network NAD

### DIFF
--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -29,10 +29,12 @@ const (
 
 	HarvesterMgmtClusterNetworkLabeyKey = network.GroupName + "/" + ManagementClusterNetworkName
 
-	// defined in Harvester pkg/controller/master/storagenetwork/storage_network.go
+	// defined in Harvester pkg/util/constants.go
 	// to avoid loop references, needs to wait until Harvester move this to its const and then refers to
 	StorageNetworkAnnotation         = "storage-network.settings.harvesterhci.io"
 	StorageNetworkNetAttachDefPrefix = "storagenetwork-"
+	RWXNetworkAnnotation             = "rwx-network.settings.harvesterhci.io"
+	RWXNetworkNetAttachDefPrefix     = "rwx-network-"
 )
 
 func GetLabelKeyOfClusterNetwork(clusterNetwork string) string {

--- a/pkg/utils/nad.go
+++ b/pkg/utils/nad.go
@@ -629,32 +629,28 @@ func isMaskZero(ipnet *net.IPNet) bool {
 	return true
 }
 
-// if this nad is a storagenetwork nad
-func IsStorageNetworkNad(nad *nadv1.NetworkAttachmentDefinition) bool {
+// IsSystemNetworkNad checks if the nad is a system network nad (storage or rwx).
+func IsSystemNetworkNad(nad *nadv1.NetworkAttachmentDefinition) bool {
 	if nad == nil || nad.Namespace != HarvesterSystemNamespaceName {
 		return false
 	}
 
-	// seems Harvester webhook has no protection on this annotation
-	if nad.Annotations != nil && nad.Annotations[StorageNetworkAnnotation] == "true" {
-		return true
+	isMatch := func(annotation, prefix string) bool {
+		if nad.Annotations != nil && nad.Annotations[annotation] == "true" {
+			return true
+		}
+		return strings.HasPrefix(nad.Name, prefix)
 	}
 
-	// check name
-	if strings.HasPrefix(nad.Name, StorageNetworkNetAttachDefPrefix) {
-		return true
-	}
-
-	return false
+	return isMatch(StorageNetworkAnnotation, StorageNetworkNetAttachDefPrefix) ||
+		isMatch(RWXNetworkAnnotation, RWXNetworkNetAttachDefPrefix)
 }
 
-// filter the first active storage network nad from a list of nads
-func FilterFirstActiveStorageNetworkNad(nads []*nadv1.NetworkAttachmentDefinition) *nadv1.NetworkAttachmentDefinition {
-	if len(nads) == 0 {
-		return nil
-	}
+// FilterFirstActiveSystemNetworkNad checks for any active system network nad (storage or rwx) from a list of nads.
+// Returns the nad and its type description, or nil if none found.
+func FilterFirstActiveSystemNetworkNad(nads []*nadv1.NetworkAttachmentDefinition) *nadv1.NetworkAttachmentDefinition {
 	for _, nad := range nads {
-		if IsStorageNetworkNad(nad) && nad.DeletionTimestamp == nil {
+		if nad != nil && nad.DeletionTimestamp == nil && IsSystemNetworkNad(nad) {
 			return nad
 		}
 	}
@@ -696,21 +692,6 @@ func (n *NadGetter) ListNadsOnClusterNetwork(cnName string) ([]*nadv1.NetworkAtt
 		return nil, nil
 	}
 	return nads, nil
-}
-
-func (n *NadGetter) GetFirstActiveStorageNetworkNadOnClusterNetwork(cnName string) (*nadv1.NetworkAttachmentDefinition, error) {
-	nads, err := n.nadCache.List(HarvesterSystemNamespaceName, labels.Set(map[string]string{
-		KeyClusterNetworkLabel: cnName,
-	}).AsSelector())
-	if err != nil {
-		return nil, err
-	}
-
-	if len(nads) == 0 {
-		return nil, nil
-	}
-
-	return FilterFirstActiveStorageNetworkNad(nads), nil
 }
 
 func (n *NadGetter) NadNamesOnClusterNetwork(cnName string) ([]string, error) {

--- a/pkg/utils/nad_test.go
+++ b/pkg/utils/nad_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -145,6 +146,207 @@ func TestL2NetConf(t *testing.T) {
 			assert.NotNil(t, vis)
 			if tc.vlanCount != 0 {
 				assert.True(t, tc.vlanCount == vis.GetVlanCount())
+			}
+		})
+	}
+}
+func TestIsSystemNetworkNad(t *testing.T) {
+	tests := []struct {
+		name     string
+		nad      *nadv1.NetworkAttachmentDefinition
+		expected bool
+	}{
+		{
+			name:     "nil nad returns false",
+			nad:      nil,
+			expected: false,
+		},
+		{
+			name: "nad in wrong namespace returns false",
+			nad: &nadv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storagenetwork-vlan100",
+					Namespace: "default",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "nad with storage network annotation returns true",
+			nad: &nadv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "any-name",
+					Namespace:   HarvesterSystemNamespaceName,
+					Annotations: map[string]string{StorageNetworkAnnotation: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "nad with storage network name prefix returns true",
+			nad: &nadv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storagenetwork-vlan100",
+					Namespace: HarvesterSystemNamespaceName,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "nad with rwx network annotation returns true",
+			nad: &nadv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "any-name",
+					Namespace:   HarvesterSystemNamespaceName,
+					Annotations: map[string]string{RWXNetworkAnnotation: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "nad with rwx network name prefix returns true",
+			nad: &nadv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rwx-network-abc123",
+					Namespace: HarvesterSystemNamespaceName,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "nad in correct namespace without annotation or prefix returns false",
+			nad: &nadv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "regular-nad",
+					Namespace: HarvesterSystemNamespaceName,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsSystemNetworkNad(tc.nad))
+		})
+	}
+}
+
+func TestFilterFirstActiveSystemNetworkNad(t *testing.T) {
+	deletionTime := metav1.NewTime(time.Now())
+	tests := []struct {
+		name        string
+		nads        []*nadv1.NetworkAttachmentDefinition
+		expectedNad string // name of expected nad, empty means nil
+	}{
+		{
+			name:        "empty list returns nil",
+			nads:        []*nadv1.NetworkAttachmentDefinition{},
+			expectedNad: "",
+		},
+		{
+			name: "returns nil when no system network nad present",
+			nads: []*nadv1.NetworkAttachmentDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-nad",
+						Namespace: HarvesterSystemNamespaceName,
+					},
+				},
+			},
+			expectedNad: "",
+		},
+		{
+			name: "returns first active storage network nad",
+			nads: []*nadv1.NetworkAttachmentDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "storagenetwork-vlan100",
+						Namespace: HarvesterSystemNamespaceName,
+					},
+				},
+			},
+			expectedNad: "storagenetwork-vlan100",
+		},
+		{
+			name: "returns first active rwx network nad",
+			nads: []*nadv1.NetworkAttachmentDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rwx-network-abc123",
+						Namespace: HarvesterSystemNamespaceName,
+					},
+				},
+			},
+			expectedNad: "rwx-network-abc123",
+		},
+		{
+			name: "returns first system network nad found",
+			nads: []*nadv1.NetworkAttachmentDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "storagenetwork-vlan100",
+						Namespace: HarvesterSystemNamespaceName,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rwx-network-abc123",
+						Namespace: HarvesterSystemNamespaceName,
+					},
+				},
+			},
+			expectedNad: "storagenetwork-vlan100",
+		},
+		{
+			name: "skips deleted storage network nad, finds rwx",
+			nads: []*nadv1.NetworkAttachmentDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "storagenetwork-vlan100",
+						Namespace:         HarvesterSystemNamespaceName,
+						DeletionTimestamp: &deletionTime,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rwx-network-abc123",
+						Namespace: HarvesterSystemNamespaceName,
+					},
+				},
+			},
+			expectedNad: "rwx-network-abc123",
+		},
+		{
+			name: "skips all deleted system network nads",
+			nads: []*nadv1.NetworkAttachmentDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "storagenetwork-vlan100",
+						Namespace:         HarvesterSystemNamespaceName,
+						DeletionTimestamp: &deletionTime,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "rwx-network-abc123",
+						Namespace:         HarvesterSystemNamespaceName,
+						DeletionTimestamp: &deletionTime,
+					},
+				},
+			},
+			expectedNad: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := FilterFirstActiveSystemNetworkNad(tc.nads)
+			if tc.expectedNad == "" {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, tc.expectedNad, result.Name)
 			}
 		})
 	}

--- a/pkg/webhook/clusternetwork/validator.go
+++ b/pkg/webhook/clusternetwork/validator.go
@@ -212,8 +212,8 @@ func (c *CnValidator) checkMTUOfUpdatedMgmtClusterNetwork(oldCn, newCn *networkv
 		return err
 	}
 
-	if nad := utils.FilterFirstActiveStorageNetworkNad(nads); nad != nil {
-		return fmt.Errorf("the MTU can't be changed from %v to %v as storage network nad %s is still attached", oldMtu, newMtu, nad.Name)
+	if nad := utils.FilterFirstActiveSystemNetworkNad(nads); nad != nil {
+		return fmt.Errorf("the MTU can't be changed from %v to %v as nad %s is still attached", oldMtu, newMtu, nad.Name)
 	}
 
 	vmiGetter := utils.NewVmiGetter(c.vmiCache)

--- a/pkg/webhook/nad/validator.go
+++ b/pkg/webhook/nad/validator.go
@@ -22,8 +22,6 @@ const (
 	createErr = "can't create nad %s/%s because %w"
 	updateErr = "can't update nad %s/%s because %w"
 	deleteErr = "can't delete nad %s/%s because %w"
-
-	storageNetworkErr = "it is used by storagenetwork"
 )
 
 type Validator struct {
@@ -122,9 +120,9 @@ func (v *Validator) Update(_ *admission.Request, oldObj, newObj runtime.Object) 
 		return fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
 	}
 
-	// storagenetwork nad's params can't be changed, the only way is to clear & set storagenetwork
-	// then all storagenetwork related PODs will be replaced with new nad
-	if err := v.checkStorageNetwork(newNad); err != nil {
+	// system network nad's params can't be changed, the only way is to clear & set the network
+	// then all related PODs will be replaced with new nad
+	if err := v.checkSystemNetwork(newNad); err != nil {
 		return fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
 	}
 
@@ -334,9 +332,9 @@ func (v *Validator) checkVM(nad *cniv1.NetworkAttachmentDefinition) error {
 	return nil
 }
 
-func (v *Validator) checkStorageNetwork(nad *cniv1.NetworkAttachmentDefinition) error {
-	if utils.IsStorageNetworkNad(nad) {
-		return fmt.Errorf("%s", storageNetworkErr)
+func (v *Validator) checkSystemNetwork(nad *cniv1.NetworkAttachmentDefinition) error {
+	if utils.IsSystemNetworkNad(nad) {
+		return fmt.Errorf("system network nad's params can't be changed")
 	}
 
 	return nil

--- a/pkg/webhook/nad/validator_test.go
+++ b/pkg/webhook/nad/validator_test.go
@@ -34,6 +34,13 @@ const (
 	testKubeOVNNadConfig2 = "{\"cniVersion\":\"0.3.1\",\"name\":\"vswitch1\",\"type\":\"kube-ovn\",\"server_socket\":\"/run/openvswitch/kube-ovn-daemon.sock\", \"provider\": \"vswitch7.default.ovn\"}"
 	testSubnetName        = "vswitch1"
 	testSubnetNamespace   = "default"
+
+	testStorageNadName      = "storagenetwork-vlan100"
+	testRWXNadName          = "rwx-network-abc123"
+	testStorageNadConfigOld = "{\"cniVersion\":\"0.3.1\",\"name\":\"storagenetwork-vlan100\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}"
+	testStorageNadConfigNew = "{\"cniVersion\":\"0.3.1\",\"name\":\"storagenetwork-vlan100\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":200,\"ipam\":{}}"
+	testRWXNadConfigOld     = "{\"cniVersion\":\"0.3.1\",\"name\":\"rwx-network-abc123\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}"
+	testRWXNadConfigNew     = "{\"cniVersion\":\"0.3.1\",\"name\":\"rwx-network-abc123\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":200,\"ipam\":{}}"
 )
 
 func TestCreateNAD(t *testing.T) {
@@ -608,16 +615,91 @@ func TestCreateNAD(t *testing.T) {
 }
 
 func TestUpdateNAD(t *testing.T) {
+	testNAD := &cniv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testNadName,
+			Namespace:   testNamespace,
+			Annotations: map[string]string{"test": "test"},
+			Labels:      map[string]string{utils.KeyClusterNetworkLabel: "test-cn1"},
+		},
+		Spec: cniv1.NetworkAttachmentDefinitionSpec{
+			Config: testNadConfig1,
+		},
+	}
+
 	tests := []struct {
 		name       string
 		returnErr  bool
 		errKey     string
+		currentCN  *networkv1.ClusterNetwork
+		oldNAD     *cniv1.NetworkAttachmentDefinition
 		currentNAD *cniv1.NetworkAttachmentDefinition
 	}{
+		{
+			name:      "storage network NAD can't be updated",
+			returnErr: true,
+			errKey:    "system network nad's params can't be changed",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testCnName,
+				},
+			},
+			oldNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testStorageNadName,
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testStorageNadConfigOld,
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testStorageNadName,
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testStorageNadConfigNew,
+				},
+			},
+		},
+		{
+			name:      "rwx network NAD can't be updated",
+			returnErr: true,
+			errKey:    "system network nad's params can't be changed",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testCnName,
+				},
+			},
+			oldNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testRWXNadName,
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testRWXNadConfigOld,
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testRWXNadName,
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testRWXNadConfigNew,
+				},
+			},
+		},
 		{
 			name:      "change the cluster network on nad throws error",
 			returnErr: true,
 			errKey:    "nad bridge name can't be changed",
+			oldNAD:    testNAD,
 			currentNAD: &cniv1.NetworkAttachmentDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        testNadName,
@@ -634,6 +716,7 @@ func TestUpdateNAD(t *testing.T) {
 			name:      "change the nad type (bridge/kube-ovn) throws error",
 			returnErr: true,
 			errKey:    "nad cannot be updated",
+			oldNAD:    testNAD,
 			currentNAD: &cniv1.NetworkAttachmentDefinition{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testKubeOVNNadName,
@@ -643,18 +726,6 @@ func TestUpdateNAD(t *testing.T) {
 					Config: testKubeOVNNadConfig,
 				},
 			},
-		},
-	}
-
-	oldNad := &cniv1.NetworkAttachmentDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        testNadName,
-			Namespace:   testNamespace,
-			Annotations: map[string]string{"test": "test"},
-			Labels:      map[string]string{utils.KeyClusterNetworkLabel: "test-cn1"},
-		},
-		Spec: cniv1.NetworkAttachmentDefinitionSpec{
-			Config: testNadConfig1,
 		},
 	}
 
@@ -675,17 +746,23 @@ func TestUpdateNAD(t *testing.T) {
 			hncCache := fakeclients.HostNetworkConfigCache(nchclientset.NetworkV1beta1().HostNetworkConfigs)
 			validator := NewNadValidator(vmCache, vmiCache, cnCache, vcCache, subnetCache, true, hncCache, nadCache)
 
+			if tc.currentCN != nil {
+				cnClient := fakeclients.ClusterNetworkClient(nchclientset.NetworkV1beta1().ClusterNetworks)
+				_, err := cnClient.Create(tc.currentCN)
+				assert.NoError(t, err)
+			}
+
 			nadGvr := schema.GroupVersionResource{
 				Group:    "k8s.cni.cncf.io",
 				Version:  "v1",
 				Resource: "network-attachment-definitions",
 			}
 
-			if err := nchclientset.Tracker().Create(nadGvr, oldNad.DeepCopy(), oldNad.Namespace); err != nil {
-				t.Fatalf("failed to add nad %+v", oldNad)
+			if err := nchclientset.Tracker().Create(nadGvr, tc.oldNAD.DeepCopy(), tc.oldNAD.Namespace); err != nil {
+				t.Fatalf("failed to add nad %+v", tc.oldNAD)
 			}
 
-			err := validator.Update(nil, oldNad, tc.currentNAD)
+			err := validator.Update(nil, tc.oldNAD, tc.currentNAD)
 			assert.True(t, tc.returnErr == (err != nil))
 			if tc.returnErr {
 				assert.NotNil(t, err)

--- a/pkg/webhook/vlanconfig/validator.go
+++ b/pkg/webhook/vlanconfig/validator.go
@@ -136,7 +136,7 @@ func (v *Validator) Update(_ *admission.Request, oldObj, newObj runtime.Object) 
 		return fmt.Errorf(updateErr, oldVc.Name, err)
 	}
 
-	if err := v.checkStorageNetwork(oldVc, affectedNodes); err != nil {
+	if err := v.checkNetworkNadsAttached(oldVc, affectedNodes); err != nil {
 		return fmt.Errorf(updateErr, oldVc.Name, err)
 	}
 
@@ -166,7 +166,7 @@ func (v *Validator) Delete(_ *admission.Request, oldObj runtime.Object) error {
 		return fmt.Errorf(deleteErr, vc.Name, err)
 	}
 
-	if err := v.checkStorageNetwork(vc, nodes); err != nil {
+	if err := v.checkNetworkNadsAttached(vc, nodes); err != nil {
 		return fmt.Errorf(deleteErr, vc.Name, err)
 	}
 
@@ -278,21 +278,21 @@ func (v *Validator) validateMTU(current *networkv1.VlanConfig) error {
 	return nil
 }
 
-// if storagenetwork nad is there, and affected node number > 0, then deny
-func (v *Validator) checkStorageNetwork(vc *networkv1.VlanConfig, nodes mapset.Set[string]) error {
-	// affect no nodes
+// checkNetworkNadsAttached checks if storage network or rwx network nads are still attached
+func (v *Validator) checkNetworkNadsAttached(vc *networkv1.VlanConfig, nodes mapset.Set[string]) error {
 	if nodes == nil || nodes.Cardinality() == 0 {
 		return nil
 	}
 
-	nadGetter := utils.NewNadGetter(v.nadCache)
-	nad, err := nadGetter.GetFirstActiveStorageNetworkNadOnClusterNetwork(vc.Spec.ClusterNetwork)
+	nads, err := v.nadCache.List(utils.HarvesterSystemNamespaceName, labels.Set(map[string]string{
+		utils.KeyClusterNetworkLabel: vc.Spec.ClusterNetwork,
+	}).AsSelector())
 	if err != nil {
 		return err
 	}
 
-	if nad != nil {
-		return fmt.Errorf("the storage network nad %s is still attached", nad.Name)
+	if nad := utils.FilterFirstActiveSystemNetworkNad(nads); nad != nil {
+		return fmt.Errorf("the system network nad %s is still attached", nad.Name)
 	}
 
 	return nil

--- a/pkg/webhook/vlanconfig/validator_test.go
+++ b/pkg/webhook/vlanconfig/validator_test.go
@@ -28,13 +28,14 @@ const (
 
 func TestCreateVlanConfig(t *testing.T) {
 	tests := []struct {
-		name      string
-		returnErr bool
-		errKey    string
-		currentCN *networkv1.ClusterNetwork
-		currentVC *networkv1.VlanConfig
-		currentVS *networkv1.VlanStatus
-		newVC     *networkv1.VlanConfig
+		name       string
+		returnErr  bool
+		errKey     string
+		currentCN  *networkv1.ClusterNetwork
+		currentVC  *networkv1.VlanConfig
+		currentVS  *networkv1.VlanStatus
+		currentNAD *cniv1.NetworkAttachmentDefinition
+		newVC      *networkv1.VlanConfig
 	}{
 		{
 			name:      "VlanConfig can't be created on mgmt network",
@@ -510,6 +511,92 @@ func TestUpdateVlanConfig(t *testing.T) {
 				},
 			}, // vmi
 		},
+		{
+			name:      "VlanConfig can't be updated as storage network nad is still attached",
+			returnErr: true,
+			errKey:    "system network nad",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testCnName,
+				},
+			},
+			oldVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNewVCName,
+					Annotations: map[string]string{utils.KeyMatchedNodes: `["node1"]`},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+					Uplink: networkv1.Uplink{
+						LinkAttrs: &networkv1.LinkAttrs{MTU: utils.DefaultMTU},
+					},
+				},
+			},
+			newVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNewVCName,
+					Annotations: map[string]string{utils.KeyMatchedNodes: `["node1"]`},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+					Uplink: networkv1.Uplink{
+						LinkAttrs: &networkv1.LinkAttrs{MTU: utils.DefaultMTU + 1},
+					},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storagenetwork-vlan100",
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+			},
+		},
+		{
+			name:      "VlanConfig can't be updated as rwx network nad is still attached",
+			returnErr: true,
+			errKey:    "system network nad",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testCnName,
+				},
+			},
+			oldVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNewVCName,
+					Annotations: map[string]string{utils.KeyMatchedNodes: `["node1"]`},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+					Uplink: networkv1.Uplink{
+						LinkAttrs: &networkv1.LinkAttrs{MTU: utils.DefaultMTU},
+					},
+				},
+			},
+			newVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNewVCName,
+					Annotations: map[string]string{utils.KeyMatchedNodes: `["node1"]`},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+					Uplink: networkv1.Uplink{
+						LinkAttrs: &networkv1.LinkAttrs{MTU: utils.DefaultMTU + 1},
+					},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rwx-network-abc123",
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+			},
+		},
 	}
 
 	nadGvr := schema.GroupVersionResource{
@@ -772,6 +859,66 @@ func TestDeleteVlanConfig(t *testing.T) {
 							MTU: utils.DefaultMTU,
 						},
 					},
+				},
+			},
+		},
+		{
+			name:      "VlanConfig can't be deleted as storage network nad is still attached",
+			returnErr: true,
+			errKey:    "system network nad",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testCnName,
+				},
+			},
+			currentVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "VC1",
+					Annotations: map[string]string{utils.KeyMatchedNodes: `["node1"]`},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+					Uplink: networkv1.Uplink{
+						LinkAttrs: &networkv1.LinkAttrs{MTU: utils.DefaultMTU},
+					},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storagenetwork-vlan100",
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+			},
+		},
+		{
+			name:      "VlanConfig can't be deleted as rwx network nad is still attached",
+			returnErr: true,
+			errKey:    "system network nad",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testCnName,
+				},
+			},
+			currentVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "VC1",
+					Annotations: map[string]string{utils.KeyMatchedNodes: `["node1"]`},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+					Uplink: networkv1.Uplink{
+						LinkAttrs: &networkv1.LinkAttrs{MTU: utils.DefaultMTU},
+					},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rwx-network-abc123",
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
 				},
 			},
 		},


### PR DESCRIPTION
**Problem:**

**Solution:**

**Related Issue:**

https://github.com/harvester/harvester/issues/10235

**Test plan:**

### TC-01: VlanConfig update is blocked when RWX network NAD exists
Steps:
1. Configure RWX network setting on cluster network cn-test, confirm rwx-network-* NAD appears in harvester-system
1. Attempt to update the VlanConfig on cn-test (e.g., change MTU)
Expected: Rejected with error containing rwx network

### TC-02: VlanConfig delete is blocked when RWX network NAD exists
Steps:
1. Same setup as TC-01
1. Attempt to delete the VlanConfig
Expected: Rejected with error containing rwx network

### TC-03: VlanConfig update/delete is allowed after RWX network NAD is removed
Steps:
1. Remove the RWX network setting (NAD deleted from harvester-system)
1. Attempt to update then delete the VlanConfig
Expected: Both succeed

### TC-04: VlanConfig on a different cluster network is not affected
Steps:
1. RWX NAD exists on cn-test
2. Attempt to update/delete a VlanConfig on a different cluster network
Expected: Succeeds without error

### TC-05: RWX NAD itself cannot be directly modified
Steps:
- Attempt to kubectl patch the rwx-network-* NAD spec
Expected: Rejected with error containing rwxnetwork

### TC-06: Regression tests for storage-network
Step: follow TC-01~TC-05, but create storage-network instead.