### PR TITLE
validate VM Network vlan exclusive of storage network vlan

### DIFF
--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -38,6 +38,7 @@ const (
 	StorageNetworkNetAttachDefPrefix = "storagenetwork-"
 	RWXNetworkAnnotation             = "rwx-network.settings.harvesterhci.io"
 	RWXNetworkNetAttachDefPrefix     = "rwx-network-"
+	ExclusiveVlanStorageNetworkLabel = StorageNetworkAnnotation + "/exclusivevlan"
 )
 
 func GetLabelKeyOfClusterNetwork(clusterNetwork string) string {

--- a/pkg/utils/nad.go
+++ b/pkg/utils/nad.go
@@ -646,6 +646,29 @@ func IsSystemNetworkNad(nad *nadv1.NetworkAttachmentDefinition) bool {
 		isMatch(RWXNetworkAnnotation, RWXNetworkNetAttachDefPrefix)
 }
 
+func (nc *NetConf) HasTrunkVlanID(target int) bool {
+	for _, vt := range nc.VlanTrunk {
+		if vt.ID != nil && *vt.ID == target {
+			return true
+		}
+		if vt.MinID != nil && vt.MaxID != nil && target >= *vt.MinID && target <= *vt.MaxID {
+			return true
+		}
+	}
+	return false
+}
+
+func IsVlanOverlapping(nadConf *NetConf, snNadConf *NetConf) bool {
+	vmVlan := nadConf.GetVlanID()
+	snVlan := snNadConf.GetVlanID()
+
+	if nadConf.HasTrunkVlanID(snVlan) || snVlan == vmVlan {
+		return true
+	}
+
+	return false
+}
+
 // FilterFirstActiveSystemNetworkNad checks for any active system network nad (storage or rwx) from a list of nads.
 // Returns the nad and its type description, or nil if none found.
 func FilterFirstActiveSystemNetworkNad(nads []*nadv1.NetworkAttachmentDefinition) *nadv1.NetworkAttachmentDefinition {

--- a/pkg/webhook/nad/validator.go
+++ b/pkg/webhook/nad/validator.go
@@ -59,6 +59,10 @@ func (v *Validator) Create(_ *admission.Request, newObj runtime.Object) error {
 		return fmt.Errorf(createErr, nad.Namespace, nad.Name, err)
 	}
 
+	if err := v.checkVlanOverlapWithSN(nad, conf); err != nil {
+		return fmt.Errorf(createErr, nad.Namespace, nad.Name, err)
+	}
+
 	//allow overlay nad creation only if subnet crd/kubeovn is enabled
 	if conf.IsKubeOVNCNI() {
 		if !v.subnetEnabled {
@@ -102,6 +106,10 @@ func (v *Validator) Update(_ *admission.Request, oldObj, newObj runtime.Object) 
 	// skip the following check if the config is not changed
 	if reflect.DeepEqual(newConf, oldConf) {
 		return nil
+	}
+
+	if err := v.checkVlanOverlapWithSN(newNad, newConf); err != nil {
+		return fmt.Errorf(updateErr, newNad.Namespace, newNad.Name, err)
 	}
 
 	if err := v.checkNadTypes(oldConf, newConf); err != nil {
@@ -388,6 +396,34 @@ func (v *Validator) checkOverlayVMsUsingClusterNetwork(nad *cniv1.NetworkAttachm
 				return fmt.Errorf("hostnetworkconfig %s is using nad %s vid %d as underlay on cluster network %s, %w", hostnetworkconfig.Name, nad.Name, vlanID, clusterNetwork, err)
 			}
 		}
+	}
+
+	return nil
+}
+
+func (v *Validator) checkVlanOverlapWithSN(nad *cniv1.NetworkAttachmentDefinition, nadConf *utils.NetConf) error {
+	//check only for vlan nad with type bridge CNI
+	if utils.IsSystemNetworkNad(nad) || nadConf.IsKubeOVNCNI() {
+		return nil
+	}
+
+	snNads, err := v.nadCache.List("", labels.Set(map[string]string{
+		utils.ExclusiveVlanStorageNetworkLabel: "true",
+	}).AsSelector())
+	if err != nil {
+		return fmt.Errorf("failed to list storage network nads with exclusive vlan enabled, err %w", err)
+	}
+
+	if len(snNads) == 0 {
+		return nil
+	}
+
+	snNadConf, decodeErr := utils.DecodeNadConfigToNetConf(snNads[0])
+	if decodeErr != nil {
+		return fmt.Errorf("failed to decode storage network nad %s/%s config, err %w", snNads[0].Namespace, snNads[0].Name, decodeErr)
+	}
+	if utils.IsVlanOverlapping(nadConf, snNadConf) {
+		return fmt.Errorf("vlan %d is exclusively reserved for storage network", snNadConf.GetVlanID())
 	}
 
 	return nil

--- a/pkg/webhook/nad/validator_test.go
+++ b/pkg/webhook/nad/validator_test.go
@@ -35,12 +35,15 @@ const (
 	testSubnetName        = "vswitch1"
 	testSubnetNamespace   = "default"
 
-	testStorageNadName      = "storagenetwork-vlan100"
-	testRWXNadName          = "rwx-network-abc123"
-	testStorageNadConfigOld = "{\"cniVersion\":\"0.3.1\",\"name\":\"storagenetwork-vlan100\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}"
-	testStorageNadConfigNew = "{\"cniVersion\":\"0.3.1\",\"name\":\"storagenetwork-vlan100\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":200,\"ipam\":{}}"
-	testRWXNadConfigOld     = "{\"cniVersion\":\"0.3.1\",\"name\":\"rwx-network-abc123\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}"
-	testRWXNadConfigNew     = "{\"cniVersion\":\"0.3.1\",\"name\":\"rwx-network-abc123\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":200,\"ipam\":{}}"
+	testStorageNadName              = "storagenetwork-vlan100"
+	testUntaggedStorageNadName      = "storagenetwork-untagged"
+	testRWXNadName                  = "rwx-network-abc123"
+	testStorageNadConfigOld         = "{\"cniVersion\":\"0.3.1\",\"name\":\"storagenetwork-vlan100\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}"
+	testStorageNadConfigNew         = "{\"cniVersion\":\"0.3.1\",\"name\":\"storagenetwork-vlan100\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":200,\"ipam\":{}}"
+	testUntaggedStorageNadConfigOld = "{\"cniVersion\":\"0.3.1\",\"name\":\"storagenetwork-untagged\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"ipam\":{}}"
+	testRWXNadConfigOld             = "{\"cniVersion\":\"0.3.1\",\"name\":\"rwx-network-abc123\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}"
+	testRWXNadConfigNew             = "{\"cniVersion\":\"0.3.1\",\"name\":\"rwx-network-abc123\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":200,\"ipam\":{}}"
+	testNadTrunkConfig              = "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":0,\"ipam\":{},\"vlanTrunk\":[{\"minID\":5,\"maxID\":10},{\"minID\":300,\"maxID\":320},{\"minID\":25,\"maxID\":25}]}"
 )
 
 func TestCreateNAD(t *testing.T) {
@@ -570,6 +573,210 @@ func TestCreateNAD(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "NAD can't be created as VLAN overlaps with exclusive storage network NAD",
+			returnErr: true,
+			errKey:    "vlan 100 is exclusively reserved for storage network",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNadName,
+					Namespace:   utils.HarvesterSystemNamespaceName,
+					Annotations: map[string]string{utils.StorageNetworkAnnotation: "true"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName, utils.ExclusiveVlanStorageNetworkLabel: "true"},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}",
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "net2-vlan",
+					Namespace: testNamespace,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}",
+				},
+			},
+		},
+		{
+			name:      "NAD can be created as VLAN does not overlap with exclusive storage network NAD",
+			returnErr: false,
+			errKey:    "",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testStorageNadName,
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testStorageNadConfigOld,
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "net2-vlan",
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net2-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":200,\"ipam\":{}}",
+				},
+			},
+		},
+		{
+			name:      "NAD can be created as VLAN  overlap with exclusive storage network NAD but exclusive vlan is not enabled",
+			returnErr: false,
+			errKey:    "",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testStorageNadName,
+					Namespace:   utils.HarvesterSystemNamespaceName,
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+					Annotations: map[string]string{utils.StorageNetworkAnnotation: "true"},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testStorageNadConfigOld,
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "net2-vlan",
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net2-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}",
+				},
+			},
+		},
+		{
+			name:      "NAD can be created when no exclusive storage network NAD exists",
+			returnErr: false,
+			errKey:    "",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "net3-vlan",
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net3-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":300,\"ipam\":{}}",
+				},
+			},
+		},
+		{
+			name:      "NAD can be created with valid trunk VLAN config",
+			returnErr: false,
+			errKey:    "",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNadName,
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testNadTrunkConfig,
+				},
+			},
+		},
+		{
+			name:      "NAD can't be created as trunk VLAN range overlaps with exclusive storage network NAD",
+			returnErr: true,
+			errKey:    "vlan 100 is exclusively reserved for storage network",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testStorageNadName,
+					Namespace:   utils.HarvesterSystemNamespaceName,
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName, utils.ExclusiveVlanStorageNetworkLabel: "true"},
+					Annotations: map[string]string{utils.StorageNetworkAnnotation: "true"},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testStorageNadConfigOld,
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "net4-vlan",
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net4-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":0,\"vlanTrunk\":[{\"minID\":100,\"maxID\":105}],\"ipam\":{}}",
+				},
+			},
+		},
+		{
+			name:      "Overlay NAD can be created with untagged storage network NAD with exclusive vlan enabled",
+			returnErr: false,
+			errKey:    "",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testUntaggedStorageNadName,
+					Namespace: utils.HarvesterSystemNamespaceName,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName, utils.ExclusiveVlanStorageNetworkLabel: "true"},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testUntaggedStorageNadConfigOld,
+				},
+			},
+			newNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testKubeOVNNadName,
+					Namespace: testKubeOVNNamespace,
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testKubeOVNNadConfig,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -600,6 +807,18 @@ func TestCreateNAD(t *testing.T) {
 			if tc.currentCN != nil {
 				_, err := cnClient.Create(tc.currentCN)
 				assert.NoError(t, err)
+			}
+
+			if tc.currentNAD != nil {
+				nadGvr := schema.GroupVersionResource{
+					Group:    "k8s.cni.cncf.io",
+					Version:  "v1",
+					Resource: "network-attachment-definitions",
+				}
+
+				if err := nchclientset.Tracker().Create(nadGvr, tc.currentNAD.DeepCopy(), tc.currentNAD.Namespace); err != nil {
+					t.Fatalf("failed to add nad %+v", tc.currentNAD)
+				}
 			}
 
 			validator := NewNadValidator(vmCache, vmiCache, cnCache, vcCache, subnetCache, true, hncCache, nadCache)
@@ -634,6 +853,7 @@ func TestUpdateNAD(t *testing.T) {
 		currentCN  *networkv1.ClusterNetwork
 		oldNAD     *cniv1.NetworkAttachmentDefinition
 		currentNAD *cniv1.NetworkAttachmentDefinition
+		snNAD      *cniv1.NetworkAttachmentDefinition
 	}{
 		{
 			name:      "storage network NAD can't be updated",
@@ -727,6 +947,39 @@ func TestUpdateNAD(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "NAD can't be created as VLAN overlaps with exclusive storage network NAD",
+			returnErr: true,
+			errKey:    "vlan 100 is exclusively reserved for storage network",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			oldNAD: testNAD,
+			snNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sn-vlan",
+					Namespace:   utils.HarvesterSystemNamespaceName,
+					Annotations: map[string]string{utils.StorageNetworkAnnotation: "true"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName, utils.ExclusiveVlanStorageNetworkLabel: "true"},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"sn-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}",
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testNadName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":100,\"ipam\":{}}",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -762,6 +1015,11 @@ func TestUpdateNAD(t *testing.T) {
 				t.Fatalf("failed to add nad %+v", tc.oldNAD)
 			}
 
+			if tc.snNAD != nil {
+				if err := nchclientset.Tracker().Create(nadGvr, tc.snNAD.DeepCopy(), tc.snNAD.Namespace); err != nil {
+					t.Fatalf("failed to add nad %+v", tc.snNAD)
+				}
+			}
 			err := validator.Update(nil, tc.oldNAD, tc.currentNAD)
 			assert.True(t, tc.returnErr == (err != nil))
 			if tc.returnErr {


### PR DESCRIPTION
Problem:
VM Network and Storage network can use same vlan currently which do not allow proper isolation of storage network traffic.
By enabling exclusive vlan on storage network, network controller can make sure to reject NAD config with same vlan id as storage network enabling proper isolation

Solution:
Reject VM Networks with vid same as storage network if exclusive vlan is configured on storage network settings

Related Issue:
https://github.com/harvester/harvester/issues/9622

Test plan:
case 1: VM Network access or untagged
1.Create storage network with vlan id 27 successfully and update the settings to include exclusiveVlan as true as below
value: '{"vlan":27,"exclusiveVlan":true,"clusterNetwork":"cluster","range":"27.0.0.0/24"}'

2.Create a VM Network L2VlanNetwork with mode access with vlan-id 27
3.It should be rejected by webhook

case 2: Trunk vlan
1.storage network created from case 1 exists.
2.Create a VM Network L2VlanNetwork with mode trunk with min and max ranges 25-30,100-200,30-40
3.It should be rejected by webhook

case 3: Create access or trunk vlan which not have vlan 27
The configuration should be accepted and VM Network must be created successfully.

