### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=InvalidDefaultArgInFrom
 
-FROM registry.suse.com/bci/golang:1.25.7 AS builder
+FROM registry.suse.com/bci/golang:1.26 AS builder
 ARG MK_HOST_ARCH
 ENV ARCH=$MK_HOST_ARCH
 RUN zypper -n rm container-suseconnect && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-network-controller
 
-go 1.25.7
+go 1.26
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.18


### PR DESCRIPTION
**Changes:**

Bump golang version as part of internal audit.

**Related Issue:**

https://github.com/harvester/harvester/issues/10725

**Test plan:**

* Run `make ci` locally.
* GH CI build.