### PR TITLE
vlanconfig info for mgmt clusternetwork

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -87,7 +87,7 @@ func main() {
 			Name:        "controller-user",
 			EnvVar:      "CONTROLLER_USER_NAME",
 			Destination: &options.ControllerUsername,
-			Value:       "harvester-load-balancer-webhook",
+			Value:       "system:serviceaccount:harvester-system:harvester-network-controller",
 			Usage:       "The harvester controller username",
 		},
 		cli.StringFlag{

--- a/pkg/controller/agent/linkmonitor/controller.go
+++ b/pkg/controller/agent/linkmonitor/controller.go
@@ -7,12 +7,14 @@ import (
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
 	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester-network-controller/pkg/config"
 	ctlnetworkv1 "github.com/harvester/harvester-network-controller/pkg/generated/controllers/network.harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester-network-controller/pkg/network/monitor"
+	"github.com/harvester/harvester-network-controller/pkg/utils"
 )
 
 const (
@@ -23,6 +25,8 @@ type Handler struct {
 	nodeName string
 
 	nodeCache    ctlcorev1.NodeCache
+	vcCache      ctlnetworkv1.VlanConfigCache
+	vcClient     ctlnetworkv1.VlanConfigClient
 	lmController ctlnetworkv1.LinkMonitorController
 	lmClient     ctlnetworkv1.LinkMonitorClient
 
@@ -32,10 +36,13 @@ type Handler struct {
 func Register(ctx context.Context, management *config.Management) error {
 	lms := management.HarvesterNetworkFactory.Network().V1beta1().LinkMonitor()
 	nodes := management.CoreFactory.Core().V1().Node()
+	vcs := management.HarvesterNetworkFactory.Network().V1beta1().VlanConfig()
 
 	h := &Handler{
 		nodeName:     management.Options.NodeName,
 		nodeCache:    nodes.Cache(),
+		vcCache:      vcs.Cache(),
+		vcClient:     vcs,
 		lmController: lms,
 		lmClient:     lms,
 	}
@@ -75,6 +82,10 @@ func (h Handler) OnChange(_ string, lm *networkv1.LinkMonitor) (*networkv1.LinkM
 
 	if err := h.syncLinkStatus(lm); err != nil {
 		return nil, fmt.Errorf("synchronize links to link monitor %s failed, error: %w", lm.Name, err)
+	}
+
+	if lm.Name == utils.ManagementClusterNetworkName {
+		return nil, h.updateMgmtVlanConfig()
 	}
 
 	return lm, nil
@@ -206,4 +217,36 @@ func (h Handler) syncLinkStatus(lm *networkv1.LinkMonitor) error {
 	}
 
 	return h.updateStatus(lm, linkStatusList)
+}
+
+// update mgmt vlanconfig when mgmt cluster link params change
+func (h Handler) updateMgmtVlanConfig() error {
+	mgmtVlanConfigName := utils.GetMgmtVlanConfigName(h.nodeName)
+	vc, err := h.vcCache.Get(mgmtVlanConfigName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logrus.Infof("no VlanConfig found for mgmt cluster network")
+			return nil
+		}
+		return fmt.Errorf("failed to get VlanConfig %s: %w", mgmtVlanConfigName, err)
+	}
+
+	mgmtIntfInfo, err := utils.GetMgmtBondInfo()
+	if err != nil {
+		logrus.Errorf("failed to get mgmt interface info: %v", err)
+		return err
+	}
+	vcCopy := vc.DeepCopy()
+
+	if !utils.BuildUpdatedVlanConfig(vcCopy, mgmtIntfInfo) {
+		return nil
+	}
+
+	_, err = h.vcClient.Update(vcCopy)
+	if err != nil {
+		return fmt.Errorf("failed to update VlanConfig %s: %w", vcCopy.Name, err)
+	}
+
+	logrus.Infof("updated VlanConfig %s with new info: MTU=%d, BondMode=%s, NICs=%v", vcCopy.Name, vcCopy.Spec.Uplink.LinkAttrs.MTU, vcCopy.Spec.Uplink.BondOptions.Mode, vcCopy.Spec.Uplink.NICs)
+	return nil
 }

--- a/pkg/controller/agent/vlanconfig/controller.go
+++ b/pkg/controller/agent/vlanconfig/controller.go
@@ -79,9 +79,10 @@ func Register(ctx context.Context, management *config.Management) error {
 }
 
 func (h Handler) OnChange(_ string, vc *networkv1.VlanConfig) (*networkv1.VlanConfig, error) {
-	if vc == nil || vc.DeletionTimestamp != nil {
+	if vc == nil || vc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName || vc.DeletionTimestamp != nil {
 		return nil, nil
 	}
+
 	logrus.Infof("vlan config %s has been changed, spec: %+v", vc.Name, vc.Spec)
 
 	isMatched, err := h.MatchNode(vc)
@@ -113,7 +114,7 @@ func (h Handler) OnChange(_ string, vc *networkv1.VlanConfig) (*networkv1.VlanCo
 }
 
 func (h Handler) OnRemove(_ string, vc *networkv1.VlanConfig) (*networkv1.VlanConfig, error) {
-	if vc == nil {
+	if vc == nil || vc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
 		return nil, nil
 	}
 
@@ -137,6 +138,11 @@ func (h Handler) initialize() error {
 	if err := iface.DisableBridgeNF(); err != nil {
 		return fmt.Errorf("disable net.bridge.bridge-nf-call-iptables failed, error: %v", err)
 	}
+
+	if err := h.CreateOrUpdateMgmtVlanConfig(); err != nil {
+		return fmt.Errorf("mgmt vlanconfig error: %w", err)
+	}
+
 	return nil
 }
 
@@ -461,4 +467,89 @@ func (h Handler) removeNodeLabel(vs *networkv1.VlanStatus) error {
 // vlanstatus name: <vc name>-<node name>-<crc32 checksum>
 func (h Handler) statusName(clusterNetwork string) string {
 	return utils.Name("", clusterNetwork, h.nodeName)
+}
+
+func (h *Handler) createMgmtVlanConfig(vc *networkv1.VlanConfig) error {
+	_, err := h.vcClient.Create(vc)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			logrus.Debugf("%s already exists", utils.GetMgmtVlanConfigName(h.nodeName))
+			return nil
+		}
+
+		return fmt.Errorf("failed to create mgmt-vlanconfig %s: %w",
+			utils.GetMgmtVlanConfigName(h.nodeName), err)
+	}
+
+	logrus.Infof("created VlanConfig %s with MTU=%d BondMode=%s NICs=%v", vc.Name, vc.Spec.Uplink.LinkAttrs.MTU, vc.Spec.Uplink.BondOptions.Mode, vc.Spec.Uplink.NICs)
+	return nil
+}
+
+// CreateOrUpdateMgmtVlanConfig checks mgmt-bo, gathers info, and creates or updates a VlanConfig resource.
+func (h *Handler) CreateOrUpdateMgmtVlanConfig() error {
+	mgmtInfo, err := utils.GetMgmtBondInfo()
+	if err != nil {
+		logrus.Warnf("mgmt interface info not found, create an empty mgmt vlanconfig: %v", err)
+		if err := h.createMgmtVlanConfig(&networkv1.VlanConfig{ObjectMeta: metav1.ObjectMeta{
+			Name: utils.GetMgmtVlanConfigName(h.nodeName),
+		}}); err != nil {
+			return fmt.Errorf("failed to create empty mgmt vlanconfig: %w", err)
+		}
+		return nil
+	}
+
+	return h.createOrUpdateMgmtVlanConfig(mgmtInfo)
+}
+
+func (h *Handler) createOrUpdateMgmtVlanConfig(mgmtInfo *utils.MgmtBondInterfaceInfo) error {
+	name := utils.GetMgmtVlanConfigName(h.nodeName)
+
+	existing, err := h.vcCache.Get(name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// Resource does not exist -> create using mgmtInfo
+	if apierrors.IsNotFound(err) {
+		vc := &networkv1.VlanConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					utils.KeyClusterNetworkLabel: utils.ManagementClusterNetworkName,
+				},
+			},
+			Spec: networkv1.VlanConfigSpec{
+				ClusterNetwork: utils.ManagementClusterNetworkName,
+				Uplink: networkv1.Uplink{
+					BondOptions: &networkv1.BondOptions{
+						Mode:   networkv1.BondMode(mgmtInfo.BondMode),
+						Miimon: -1,
+					},
+					LinkAttrs: &networkv1.LinkAttrs{
+						MTU:    mgmtInfo.MTU,
+						TxQLen: -1,
+					},
+					NICs: mgmtInfo.SlaveNames,
+				},
+			},
+		}
+
+		return h.createMgmtVlanConfig(vc)
+	}
+
+	// Resource exists -> update if required
+	vcCopy := existing.DeepCopy()
+
+	if !utils.BuildUpdatedVlanConfig(vcCopy, mgmtInfo) {
+		return nil
+	}
+
+	_, err = h.vcClient.Update(vcCopy)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("updated VlanConfig %s with MTU=%d BondMode=%s NICs=%v", vcCopy.Name, vcCopy.Spec.Uplink.LinkAttrs.MTU, vcCopy.Spec.Uplink.BondOptions.Mode, vcCopy.Spec.Uplink.NICs)
+
+	return nil
 }

--- a/pkg/controller/manager/node/controller.go
+++ b/pkg/controller/manager/node/controller.go
@@ -9,6 +9,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -83,6 +84,10 @@ func (h Handler) OnChange(_ string, node *corev1.Node) (*corev1.Node, error) {
 		return nil, err
 	}
 	for _, vc := range vcs {
+		if vc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
+			// skip vlan config with management cluster network
+			continue
+		}
 		if err := h.updateMatchedNodeAnnotation(vc, node); err != nil {
 			return nil, fmt.Errorf("failed to update matched node annotation, vc: %s, node: %s, error: %w",
 				vc.Name, node.Name, err)
@@ -242,9 +247,27 @@ func (h Handler) removeNodeFromVlanConfig(nodeName string) error {
 	}
 
 	for _, vc := range vcs {
+		if vc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
+			if vc.Name == utils.GetMgmtVlanConfigName(nodeName) {
+				if err := h.removeMgmtVlanConfig(nodeName); err != nil {
+					return err
+				}
+			}
+			continue
+		}
 		if err := h.removeNodeFromOneVlanConfig(vc, nodeName); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (h Handler) removeMgmtVlanConfig(nodeName string) error {
+	vcName := utils.GetMgmtVlanConfigName(nodeName)
+
+	if err := h.vcClient.Delete(vcName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	return nil

--- a/pkg/controller/manager/vlanconfig/controller.go
+++ b/pkg/controller/manager/vlanconfig/controller.go
@@ -24,6 +24,7 @@ type Handler struct {
 	cnCache  ctlnetworkv1.ClusterNetworkCache
 	vsCache  ctlnetworkv1.VlanStatusCache
 	vcCache  ctlnetworkv1.VlanConfigCache
+	vcClient ctlnetworkv1.VlanConfigClient
 }
 
 func Register(ctx context.Context, management *config.Management) error {
@@ -36,6 +37,7 @@ func Register(ctx context.Context, management *config.Management) error {
 		cnCache:  cns.Cache(),
 		vsCache:  vss.Cache(),
 		vcCache:  vcs.Cache(),
+		vcClient: vcs,
 	}
 
 	vcs.OnChange(ctx, ControllerName, handler.EnsureClusterNetwork)
@@ -47,7 +49,7 @@ func Register(ctx context.Context, management *config.Management) error {
 }
 
 func (h Handler) EnsureClusterNetwork(_ string, vc *networkv1.VlanConfig) (*networkv1.VlanConfig, error) {
-	if vc == nil || vc.DeletionTimestamp != nil {
+	if vc == nil || vc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName || vc.DeletionTimestamp != nil {
 		return nil, nil
 	}
 
@@ -60,7 +62,7 @@ func (h Handler) EnsureClusterNetwork(_ string, vc *networkv1.VlanConfig) (*netw
 }
 
 func (h Handler) SetClusterNetworkReady(_ string, vs *networkv1.VlanStatus) (*networkv1.VlanStatus, error) {
-	if vs == nil || vs.DeletionTimestamp != nil {
+	if vs == nil || vs.Status.ClusterNetwork == utils.ManagementClusterNetworkName || vs.DeletionTimestamp != nil {
 		return nil, nil
 	}
 
@@ -75,7 +77,7 @@ func (h Handler) SetClusterNetworkReady(_ string, vs *networkv1.VlanStatus) (*ne
 }
 
 func (h Handler) SetClusterNetworkUnready(_ string, vs *networkv1.VlanStatus) (*networkv1.VlanStatus, error) {
-	if vs == nil {
+	if vs == nil || vs.Status.ClusterNetwork == utils.ManagementClusterNetworkName {
 		return nil, nil
 	}
 
@@ -190,7 +192,7 @@ func (h Handler) setClusterNetworkUnready(vs *networkv1.VlanStatus) error {
 }
 
 func (h Handler) OnVlanConfigRemove(_ string, vc *networkv1.VlanConfig) (*networkv1.VlanConfig, error) {
-	if vc == nil {
+	if vc == nil || vc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
 		return nil, nil
 	}
 

--- a/pkg/utils/bondInterface.go
+++ b/pkg/utils/bondInterface.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"fmt"
+
+	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+type MgmtBondInterfaceInfo struct {
+	MTU        int
+	BondMode   string
+	SlaveNames []string
+}
+
+func GetMgmtBondInfo() (*MgmtBondInterfaceInfo, error) {
+	// Find the mgmt-bo bond interface
+	mgmtBo, err := netlink.LinkByName(ManagementClusterNetworkBondDevicePrefix)
+	if err != nil {
+		logrus.Errorf("failed to get %s interface: %v", ManagementClusterNetworkBondDevicePrefix, err)
+		return nil, err
+	}
+
+	bond, ok := mgmtBo.(*netlink.Bond)
+	if !ok {
+		logrus.Errorf("failed to read bond mode for %s: %v", ManagementClusterNetworkBondDevicePrefix, err)
+		return nil, fmt.Errorf("interface %s is not a bond device (got %T)", ManagementClusterNetworkBondDevicePrefix, mgmtBo)
+	}
+
+	// Get all interfaces and find slaves of mgmt-bo
+	links, err := netlink.LinkList()
+	if err != nil {
+		logrus.Errorf("failed to list interfaces: %v", err)
+		return nil, err
+	}
+	var slaveNames []string
+	for _, l := range links {
+		if l.Attrs().MasterIndex == mgmtBo.Attrs().Index {
+			slaveNames = append(slaveNames, l.Attrs().Name)
+		}
+	}
+
+	mgmtInfo := &MgmtBondInterfaceInfo{
+		MTU:        mgmtBo.Attrs().MTU,
+		BondMode:   bond.Mode.String(),
+		SlaveNames: slaveNames,
+	}
+
+	return mgmtInfo, nil
+}
+
+func BuildUpdatedVlanConfig(vc *networkv1.VlanConfig, mgmtIntfInfo *MgmtBondInterfaceInfo) bool {
+	if vc == nil {
+		return false
+	}
+
+	changed := false
+
+	if vc.Spec.Uplink.LinkAttrs == nil {
+		vc.Spec.Uplink.LinkAttrs = &networkv1.LinkAttrs{TxQLen: -1}
+	}
+	if vc.Spec.Uplink.BondOptions == nil {
+		vc.Spec.Uplink.BondOptions = &networkv1.BondOptions{Miimon: -1}
+	}
+
+	if vc.Spec.Uplink.LinkAttrs.MTU != mgmtIntfInfo.MTU {
+		vc.Spec.Uplink.LinkAttrs.MTU = mgmtIntfInfo.MTU
+		changed = true
+	}
+
+	if vc.Spec.Uplink.BondOptions.Mode != networkv1.BondMode(mgmtIntfInfo.BondMode) {
+		vc.Spec.Uplink.BondOptions.Mode = networkv1.BondMode(mgmtIntfInfo.BondMode)
+		changed = true
+	}
+
+	if !compareStringSlices(vc.Spec.Uplink.NICs, mgmtIntfInfo.SlaveNames) {
+		vc.Spec.Uplink.NICs = mgmtIntfInfo.SlaveNames
+		changed = true
+	}
+
+	return changed
+}
+
+// Helper to compare two string slices
+func compareStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		m[v] = struct{}{}
+	}
+	for _, v := range b {
+		if _, ok := m[v]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -22,6 +22,9 @@ const (
 
 	// format: e.g. mgmt-br
 	ManagementClusterNetworkDevicePrefix = ManagementClusterNetworkName + BridgeSuffix
+
+	// format: e.g. mgmt-bo
+	ManagementClusterNetworkBondDevicePrefix = ManagementClusterNetworkName + BondSuffix
 )
 
 func HasMgmtClusterNetworkVlanDevicePrefix(link string) bool {

--- a/pkg/utils/mgmt.go
+++ b/pkg/utils/mgmt.go
@@ -1,7 +1,30 @@
 package utils
 
-const ManagementClusterNetworkName = "mgmt"
+import (
+	"github.com/harvester/webhook/pkg/server/admission"
+)
+
+const (
+	ManagementClusterNetworkName = "mgmt"
+	MgmtVlanConfigPrefix         = "mgmt-vlanconfig-"
+)
 
 func IsManagementClusterNetwork(cnName string) bool {
 	return cnName == ManagementClusterNetworkName
+}
+
+func IsUserRequestForMgmtCluster(req *admission.Request, clusterNetwork string) bool {
+	if clusterNetwork != ManagementClusterNetworkName {
+		return false
+	}
+
+	if req != nil && !req.IsFromController() {
+		return true
+	}
+
+	return false
+}
+
+func GetMgmtVlanConfigName(nodeName string) string {
+	return MgmtVlanConfigPrefix + nodeName
 }

--- a/pkg/webhook/vlanconfig/mutator.go
+++ b/pkg/webhook/vlanconfig/mutator.go
@@ -32,6 +32,10 @@ func NewVlanConfigMutator(nodeCache ctlcorev1.NodeCache) *Mutator {
 func (m *Mutator) Create(_ *admission.Request, newObj runtime.Object) (admission.Patch, error) {
 	vlanConfig := newObj.(*networkv1.VlanConfig)
 
+	//skip matched node annotation for mgmt vlanconfig
+	if vlanConfig.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
+		return nil, nil
+	}
 	annotationPatch, err := m.matchNodes(vlanConfig)
 	if err != nil {
 		return nil, fmt.Errorf(createErr, vlanConfig.Name, err)
@@ -49,6 +53,10 @@ func (m *Mutator) Update(_ *admission.Request, oldObj, newObj runtime.Object) (a
 		return nil, nil
 	}
 
+	//skip matched node annotation for mgmt vlanconfig
+	if newVc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
+		return nil, nil
+	}
 	// continue the mutation even if spec is not changed, to ensure those labels
 	var cnLabelPatch, annotationPatch admission.Patch
 	if newVc.Spec.ClusterNetwork != oldVc.Spec.ClusterNetwork {

--- a/pkg/webhook/vlanconfig/validator.go
+++ b/pkg/webhook/vlanconfig/validator.go
@@ -54,16 +54,17 @@ func NewVlanConfigValidator(
 
 var _ admission.Validator = &Validator{}
 
-func (v *Validator) Create(_ *admission.Request, newObj runtime.Object) error {
+func (v *Validator) Create(req *admission.Request, newObj runtime.Object) error {
 	vc := newObj.(*networkv1.VlanConfig)
+
+	// skip vlanconfig creation if the request is not from controller for mgmt cluster network
+	if utils.IsUserRequestForMgmtCluster(req, vc.Spec.ClusterNetwork) {
+		return fmt.Errorf(createErr, vc.Name, fmt.Errorf("users can't create vlanConfig for %s cluster network",
+			utils.ManagementClusterNetworkName))
+	}
 
 	if _, err := utils.IsClusterNetworkNameValid(vc.Spec.ClusterNetwork); err != nil {
 		return fmt.Errorf(createErr, vc.Name, err)
-	}
-
-	if vc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
-		return fmt.Errorf(createErr, vc.Name, fmt.Errorf("cluster network can't be %s",
-			utils.ManagementClusterNetworkName))
 	}
 
 	// check if clusternetwork exists
@@ -88,7 +89,7 @@ func (v *Validator) Create(_ *admission.Request, newObj runtime.Object) error {
 	return nil
 }
 
-func (v *Validator) Update(_ *admission.Request, oldObj, newObj runtime.Object) error {
+func (v *Validator) Update(req *admission.Request, oldObj, newObj runtime.Object) error {
 	oldVc := oldObj.(*networkv1.VlanConfig)
 	newVc := newObj.(*networkv1.VlanConfig)
 
@@ -97,8 +98,9 @@ func (v *Validator) Update(_ *admission.Request, oldObj, newObj runtime.Object) 
 		return nil
 	}
 
-	if newVc.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
-		return fmt.Errorf(updateErr, newVc.Name, fmt.Errorf("cluster network can't be %s",
+	// skip vlanconfig update if the request is not from controller for mgmt cluster network
+	if utils.IsUserRequestForMgmtCluster(req, newVc.Spec.ClusterNetwork) {
+		return fmt.Errorf(updateErr, newVc.Name, fmt.Errorf("users can't update vlanConfig for %s cluster network",
 			utils.ManagementClusterNetworkName))
 	}
 
@@ -156,8 +158,13 @@ func getAffectedNodes(oldVc, newVc *networkv1.VlanConfig, oldNodes, newNodes map
 	return oldNodes.Difference(newNodes)
 }
 
-func (v *Validator) Delete(_ *admission.Request, oldObj runtime.Object) error {
+func (v *Validator) Delete(req *admission.Request, oldObj runtime.Object) error {
 	vc := oldObj.(*networkv1.VlanConfig)
+
+	if utils.IsUserRequestForMgmtCluster(req, vc.Spec.ClusterNetwork) {
+		return fmt.Errorf(deleteErr, vc.Name, fmt.Errorf("users can't delete vlanConfig for %s cluster network",
+			utils.ManagementClusterNetworkName))
+	}
 
 	nodes, err := getMatchNodes(vc)
 	if err != nil {
@@ -254,6 +261,9 @@ func getMatchNodes(vc *networkv1.VlanConfig) (mapset.Set[string], error) {
 }
 
 func (v *Validator) validateMTU(current *networkv1.VlanConfig) error {
+	if current.Spec.ClusterNetwork == utils.ManagementClusterNetworkName {
+		return nil
+	}
 	// MTU can be 0, it means user does not input and the default value is used
 	mtu := utils.GetMTUFromVlanConfig(current)
 	if !utils.IsValidMTU(mtu) {

--- a/pkg/webhook/vlanconfig/validator_test.go
+++ b/pkg/webhook/vlanconfig/validator_test.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rancher/wrangler/v3/pkg/webhook"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -15,6 +18,8 @@ import (
 	"github.com/harvester/harvester-network-controller/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester-network-controller/pkg/utils"
 	"github.com/harvester/harvester-network-controller/pkg/utils/fakeclients"
+	webhookConfig "github.com/harvester/webhook/pkg/config"
+	"github.com/harvester/webhook/pkg/server/admission"
 )
 
 const (
@@ -23,7 +28,6 @@ const (
 	testVMName    = "vm1"
 	testNamespace = "test"
 	testNewVCName = "newVC"
-	testNadConfig = "{\"cniVersion\":\"0.3.1\",\"name\":\"net1-vlan\",\"type\":\"bridge\",\"bridge\":\"test-cn-br\",\"promiscMode\":true,\"vlan\":300,\"ipam\":{}}"
 )
 
 func TestCreateVlanConfig(t *testing.T) {
@@ -36,9 +40,10 @@ func TestCreateVlanConfig(t *testing.T) {
 		currentVS  *networkv1.VlanStatus
 		currentNAD *cniv1.NetworkAttachmentDefinition
 		newVC      *networkv1.VlanConfig
+		userReq    bool
 	}{
 		{
-			name:      "VlanConfig can't be created on mgmt network",
+			name:      "VlanConfig can't be created on mgmt network by user request",
 			returnErr: true,
 			errKey:    "mgmt",
 			newVC: &networkv1.VlanConfig{
@@ -48,6 +53,27 @@ func TestCreateVlanConfig(t *testing.T) {
 				},
 				Spec: networkv1.VlanConfigSpec{
 					ClusterNetwork: utils.ManagementClusterNetworkName,
+				},
+			},
+			userReq: true,
+		},
+		{
+			name:      "VlanConfig can be created on mgmt network by controller request",
+			returnErr: false,
+			errKey:    "",
+			newVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testOnMgmt",
+					Annotations: map[string]string{"test": "test"},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: utils.ManagementClusterNetworkName,
+				},
+			},
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        utils.ManagementClusterNetworkName,
+					Annotations: map[string]string{"test": "test"},
 				},
 			},
 		},
@@ -289,7 +315,17 @@ func TestCreateVlanConfig(t *testing.T) {
 			}
 			validator := NewVlanConfigValidator(nadCache, vcCache, vsCache, vmiCache, cnCache)
 
-			err := validator.Create(nil, tc.newVC)
+			var username string
+			if tc.userReq {
+				username = "system:admin"
+			} else {
+				username = "system:serviceaccount:harvester-system:harvester-network-controller"
+			}
+			options := &webhookConfig.Options{ControllerUsername: "system:serviceaccount:harvester-system:harvester-network-controller"}
+			webhookReq := &webhook.Request{AdmissionRequest: v1.AdmissionRequest{UserInfo: authenticationv1.UserInfo{Username: username}}}
+			req := admission.NewRequest(webhookReq, options)
+
+			err := validator.Create(req, tc.newVC)
 			assert.True(t, tc.returnErr == (err != nil))
 			if tc.returnErr {
 				assert.NotNil(t, err)


### PR DESCRIPTION
**Problem:**
Mgmt cluster network does not display the network information in UI.
Users needs the information on the mgmt interface like MTU, interfaces and bond mode which is not available in UI currently like other user defined cluster networks.
Currently the backend does not have network information of the mgmt cluster network.

**Solution:**
Create a vlanconfig per node by the vlanconfig agent controller.
- vlanconfig agent during startup initializes a vlanconfig resource for the mgmt cluster network by retrieving network information like MTU, slaves in the mgmt-bo, and bond mode using ip commands (mgmt-vlanconfig-<nodename>)
- match by mgmt cluster network rule on the link monitor agent controller to reconcile vlanconfig whenever there are changes to link parameters of mgmt-bo/mgmt-br
- Restrict create/update/delete operations on mgmt vlanconfig from user (allow only from network controller)
- skip node updates on mgmt vlanconfig
- skip other vlanconfig operations (like setup/remove vlan/uplink) on mgmt vlanconfigs
- vlanstatus are not created for mgmt vlanconfig as they are not manged by network controller

**Related Issue:**
https://github.com/harvester/harvester/issues/6110

**Test plan:**
case 1:
1.Once the network controller modules come up, check kubectl get vlanconfig - mgmt-vlanconfig must be available on per node.
2.Check if link attributes like MTU,bond mode, slaves in bond mode match the configuration done during installation.

case 2: Add/Remove slave interfaces to the mgmt-bo (any node)
1.sudo ip link add ens7 type dummy
2.sudo ip link set ens7 master mgmt-bo
3.Verify kubectl get vlanconfig mgmt-vlanconfig -o yaml (ens7 added to the links)
4.sudo ip link set ens7 nomaster
5.Verify kubectl get vlanconfig mgmt-vlanconfig-<node-name> -o yaml (ens7 removed from the links)

case 3: Update MTU on mgmt-bo
1.sudo ip link set mgmt-bo mtu 1600
2..Verify kubectl get vlanconfig mgmt-vlanconfig -o yaml (mtu changed to 1600)
3.sudo ip link set mgmt-bo mtu 1500
4..Verify kubectl get vlanconfig mgmt-vlanconfig-<node-name> -o yaml (mtu changed to 1500)

case 4: Restrict create/update/delete of mgmt vlanconfig
1.Create or update or delete the mgmt vlanconfig - webhook will throw error

UI changes:

https://github.com/harvester/harvester-ui-extension/pull/974