### PR TITLE
build: remove external frontend directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-# syntax=docker/dockerfile:1
-# check=skip=InvalidDefaultArgInFrom
-
 FROM registry.suse.com/bci/golang:1.26 AS builder
 ARG MK_HOST_ARCH
 ENV ARCH=$MK_HOST_ARCH


### PR DESCRIPTION
Modern docker installations should come with buildx capabilities. There is no need to check external builder image.
This reduce external manifest checks, which are counted as Dockerhub pull limits.

We don't need the check=skip=InvalidDefaultArgInFrom line.


