### PR TITLE
Draft:do not allow hnc with vlan id if a vlan sub interface already exists with the same id

### DIFF
--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	BridgeSuffix       = "-br"
-	BondSuffix         = "-bo"
-	DefaultValueMiimon = 100
+	BridgeSuffix          = "-br"
+	BondSuffix            = "-bo"
+	DefaultValueMiimon    = 100
+	BridgeSuffixWithVlan1 = "-br.1"
 
 	LenOfBridgeSuffix = 3 // length of BridgeSuffix
 	LenOfBondSuffix   = 3 // length of BondSuffix
@@ -43,6 +44,10 @@ func GetClusterNetworkDevicePrefix(cnName string) string {
 // e.g. cn2-br.2025
 func GetClusterNetworkBrVlanDevice(cnBrName string, vlanId uint16) string {
 	return fmt.Sprintf("%s%s%s", cnBrName, VlanSubInterfaceSpliter, fmt.Sprint(vlanId))
+}
+
+func GetClusterNetworkPrefix(cnName string) string {
+	return fmt.Sprintf("%s%s", cnName, BridgeSuffix)
 }
 
 // e.g. cn2-br.2025

--- a/pkg/webhook/hostnetworkconfig/validator.go
+++ b/pkg/webhook/hostnetworkconfig/validator.go
@@ -9,6 +9,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/harvester/webhook/pkg/server/admission"
+	"github.com/vishvananda/netlink"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -463,6 +464,55 @@ func (v *Validator) checkVCSpansAllNodes(clusterNetwork string) error {
 
 		if !matchedNodes.Contains(node.Name) {
 			return fmt.Errorf("vlanconfig does not span %s", node.Name)
+		}
+	}
+
+	return nil
+}
+
+func validateHostNetworkVLAN(vlanID int) error {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return err
+	}
+
+	for _, link := range links {
+		name := link.Attrs().Name
+
+		if vlanID == 1 {
+			// Check any cluster network bridge or VLAN 1 sub-interface
+			if !strings.HasSuffix(name, utils.BridgeSuffix) &&
+				!strings.HasSuffix(name, utils.BridgeSuffixWithVlan1) {
+				continue
+			}
+
+			addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+			if err != nil {
+				return err
+			}
+
+			if len(addrs) > 0 {
+				return fmt.Errorf(
+					"vlan 1 is already configured on interface %s with address %s",
+					name,
+					addrs[0].IPNet.String(),
+				)
+			}
+		} else {
+			// VLAN > 1:
+			// Check if another VLAN interface with same VLAN ID exists
+			vlanLink, ok := link.(*netlink.Vlan)
+			if !ok {
+				continue
+			}
+
+			if vlanLink.VlanId == vlanID {
+				return fmt.Errorf(
+					"vlan %d is already configured on interface %s",
+					vlanID,
+					name,
+				)
+			}
 		}
 	}
 

--- a/pkg/webhook/hostnetworkconfig/validator_test.go
+++ b/pkg/webhook/hostnetworkconfig/validator_test.go
@@ -1,6 +1,8 @@
 package hostnetworkconfig
 
 import (
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -17,6 +19,9 @@ import (
 	"github.com/harvester/harvester-network-controller/pkg/generated/clientset/versioned/fake"
 	"github.com/harvester/harvester-network-controller/pkg/utils"
 	"github.com/harvester/harvester-network-controller/pkg/utils/fakeclients"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
 )
 
 const (
@@ -1189,4 +1194,172 @@ func TestSameSubnet(t *testing.T) {
 			assert.Equal(t, tc.wantOK, ok, "expected sameSubnet to return %v for cidrs=%v, got %v", tc.wantOK, tc.cidrs, ok)
 		})
 	}
+}
+
+func TestValidateHostNetworkVLAN(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T)
+		vlanID  int
+		wantErr bool
+		errKey  string
+	}{
+		{
+			name:    "vlan > 1 returns error when same vlan id already exists",
+			vlanID:  2012,
+			wantErr: true,
+			errKey:  "already configured on interface",
+			setup: func(t *testing.T) {
+				parent := createBridgeLink(t, utils.GetClusterNetworkPrefix(testCnName))
+				_ = createVlanLink(t, utils.GetClusterNetworkVlanDevice(testCnName, 2012), parent.Attrs().Index, 2012)
+			},
+		},
+		{
+			name:    "vlan > 1 succeeds when only different vlan id exists",
+			vlanID:  2012,
+			wantErr: false,
+			setup: func(t *testing.T) {
+				parent := createBridgeLink(t, utils.GetClusterNetworkPrefix(testCnName))
+				_ = createVlanLink(t, utils.GetClusterNetworkVlanDevice(testCnName, 2013), parent.Attrs().Index, 2013)
+				parent1 := createBridgeLink(t, utils.GetClusterNetworkPrefix(testCnName11))
+				_ = createVlanLink(t, utils.GetClusterNetworkVlanDevice(testCnName11, 2014), parent1.Attrs().Index, 2014)
+			},
+		},
+		{
+			name:    "vlan 1 returns error when bridge has ipv4 address",
+			vlanID:  1,
+			wantErr: true,
+			errKey:  "vlan 1 is already configured on interface",
+			setup: func(t *testing.T) {
+				br := createBridgeLink(t, utils.GetClusterNetworkPrefix(testCnName))
+				addIPv4Addr(t, br, "192.168.50.10/24")
+			},
+		},
+		{
+			name:    "vlan 1 returns error when vlan sub-interface has ipv4 address",
+			vlanID:  1,
+			wantErr: true,
+			errKey:  "vlan 1 is already configured on interface",
+			setup: func(t *testing.T) {
+				parent := createBridgeLink(t, utils.GetClusterNetworkPrefix(testCnName))
+				vlan := createVlanLink(t, utils.GetClusterNetworkVlanDevice(testCnName, 1), parent.Attrs().Index, 1)
+				addIPv4Addr(t, vlan, "192.168.60.10/24")
+			},
+		},
+		{
+			name:    "vlan 1 succeeds when matching interfaces exist but no ipv4 address",
+			vlanID:  1,
+			wantErr: false,
+			setup: func(t *testing.T) {
+				_ = createBridgeLink(t, utils.GetClusterNetworkPrefix(testCnName))
+			},
+		},
+		{
+			name:    "vlan 1 succeeds when no relevant interface exists",
+			vlanID:  1,
+			wantErr: false,
+			setup: func(t *testing.T) {
+				parent := createBridgeLink(t, utils.GetClusterNetworkPrefix(testCnName))
+				vlan := createVlanLink(t, utils.GetClusterNetworkVlanDevice(testCnName, 2014), parent.Attrs().Index, 2014)
+				addIPv4Addr(t, vlan, "192.168.70.10/24")
+				_ = createBridgeLink(t, utils.GetClusterNetworkPrefix(utils.ManagementClusterNetworkName))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withIsolatedNetNS(t, func() {
+				if tc.setup != nil {
+					tc.setup(t)
+				}
+
+				err := validateHostNetworkVLAN(tc.vlanID)
+				assert.Equal(t, tc.wantErr, err != nil)
+
+				if tc.wantErr {
+					assert.Error(t, err)
+					assert.True(t, strings.Contains(err.Error(), tc.errKey), fmt.Sprintf("got error: %v", err))
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+func withIsolatedNetNS(t *testing.T, fn func()) {
+	t.Helper()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("requires linux")
+	}
+
+	runtime.LockOSThread()
+
+	origNS, err := netns.Get()
+	if err != nil {
+		runtime.UnlockOSThread()
+		t.Skipf("failed to get current netns: %v", err)
+		return
+	}
+
+	newNS, err := netns.New()
+	if err != nil {
+		_ = origNS.Close()
+		runtime.UnlockOSThread()
+		t.Skipf("requires CAP_SYS_ADMIN/CAP_NET_ADMIN to create netns: %v", err)
+		return
+	}
+
+	defer func() {
+		_ = netns.Set(origNS)
+		_ = newNS.Close()
+		_ = origNS.Close()
+		runtime.UnlockOSThread()
+	}()
+
+	fn()
+}
+
+func createBridgeLink(t *testing.T, name string) netlink.Link {
+	t.Helper()
+
+	link := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{Name: name},
+	}
+	err := netlink.LinkAdd(link)
+	assert.NoError(t, err)
+
+	out, err := netlink.LinkByName(name)
+	assert.NoError(t, err)
+	return out
+}
+
+func createVlanLink(t *testing.T, name string, parentIndex int, vlanID int) netlink.Link {
+	t.Helper()
+
+	link := &netlink.Vlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        name,
+			ParentIndex: parentIndex,
+		},
+		VlanId: vlanID,
+	}
+	err := netlink.LinkAdd(link)
+	assert.NoError(t, err)
+
+	out, err := netlink.LinkByName(name)
+	assert.NoError(t, err)
+	return out
+}
+
+func addIPv4Addr(t *testing.T, link netlink.Link, cidr string) {
+	t.Helper()
+
+	addr, err := netlink.ParseAddr(cidr)
+	assert.NoError(t, err)
+
+	err = netlink.AddrAdd(link, addr)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION

**Problem:**
VM Network exists with vlan 1 Active and reachable to gw (DHCP is active).
VMs created using this network is able to get the IP address from DHCP.
But hostnetworkconfig interface created on vlan 1 mgmt cluster, not able to get an IP address from DHCP.

**Solution:**
The issue occurs when the host is attached multiple times to the same Layer 2 network. In the VLAN 1 case, mgmt-br already represents the native/untagged VLAN 1 network, and creating mgmt-br.1 adds a second host interface to the same broadcast domain. DHCP DISCOVER packets are transmitted successfully, but the DHCP OFFER is associated with the existing interface (mgmt-br) rather than the VLAN subinterface (mgmt-br.1), causing the DHCP client to never complete lease acquisition.

More generally, a node should not have multiple host interfaces connected to the same VLAN/subnet, 

A webhook validation is added to restrict hostnetworkconfig with vlan id if matching any of the existing vlan sub interfaces with same vlan id.

**Related Issue:**
https://github.com/harvester/harvester/issues/10802

**Test plan:**


