### PR TITLE
deps: update insomniacslk/dhcp to reject malformed short IPv4 frames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.9.0
 	github.com/go-ping/ping v0.0.0-20211014180314-6e2b003bffdd
 	github.com/harvester/webhook v0.1.5
-	github.com/insomniacslk/dhcp v0.0.0-20260603135910-a415979eb11e
+	github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 	github.com/kubeovn/kube-ovn v1.13.13
 	github.com/rancher/lasso v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/insomniacslk/dhcp v0.0.0-20260603135910-a415979eb11e h1:7j1+lOuGBg7PQF1RxeVx0iP+/GpiAxSG/F+9t5JOS94=
-github.com/insomniacslk/dhcp v0.0.0-20260603135910-a415979eb11e/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82 h1:y5aU8Uvl7eyM5WNgdQvRxbMJb+zo7pD+S72/Yo4pvnQ=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv4/nclient4/conn_unix.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv4/nclient4/conn_unix.go
@@ -111,6 +111,14 @@ func (upc *BroadcastRawUDPConn) ReadFrom(b []byte) (int, net.Addr, error) {
 			continue
 		}
 
+		// The IPv4 payload must be large enough to hold a UDP header. Discarding
+		// frames that declare fewer bytes keeps the DHCP length computed below
+		// non-negative and avoids parsing trailing padding as a UDP header.
+		ipPayloadLen := int(ipHdr.payloadLength())
+		if ipPayloadLen < udpHdrLen {
+			continue
+		}
+
 		if !buf.Has(udpHdrLen) {
 			continue
 		}
@@ -128,9 +136,12 @@ func (upc *BroadcastRawUDPConn) ReadFrom(b []byte) (int, net.Addr, error) {
 			IP:   ipHdr.sourceAddress(),
 			Port: int(udpHdr.sourcePort()),
 		}
-		// Extra padding after end of IP packet should be ignored,
-		// if not dhcp option parsing will fail.
-		dhcpLen := int(ipHdr.payloadLength()) - udpHdrLen
+		// Extra padding after the end of the IP payload is ignored; otherwise
+		// dhcp option parsing would fail.
+		dhcpLen := ipPayloadLen - udpHdrLen
+		if !buf.Has(dhcpLen) {
+			continue
+		}
 		return copy(b, buf.Consume(dhcpLen)), srcAddr, nil
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -93,7 +93,7 @@ github.com/harvester/webhook/pkg/error
 github.com/harvester/webhook/pkg/server
 github.com/harvester/webhook/pkg/server/admission
 github.com/harvester/webhook/pkg/server/conversion
-# github.com/insomniacslk/dhcp v0.0.0-20260603135910-a415979eb11e
+# github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82
 ## explicit; go 1.23.0
 github.com/insomniacslk/dhcp/dhcpv4
 github.com/insomniacslk/dhcp/dhcpv4/nclient4


### PR DESCRIPTION
This repo pins insomniacslk/dhcp at `v0.0.0-20260603135910-a415979eb11e`, before insomniacslk/dhcp#583, and this moves it to the merge commit.

Before #583, `BroadcastRawUDPConn.ReadFrom` (`dhcpv4/nclient4/conn_unix.go`) subtracted the 8-byte UDP header from the IPv4 payload length without checking the payload was at least that long, so a reply with a smaller declared payload gave a negative DHCP length and panicked on a bad slice bound.

Only one of the two DHCP paths here reaches that code. `sendDiscoverMessage` in `pkg/helper/dhcp.go` builds its client with `nclient4.New(iface)` (default raw broadcast) and `DiscoverOffer` reads through the affected `ReadFrom`; `NewLeaseManager` in `pkg/controller/agent/hostnetworkconfig/leasemanager.go` uses the same default client via `client.Request`. `sendInformMessage` passes `nclient4.WithUnicast`, so its replies come back on a normal UDP socket and it isn't affected.

I wrote the upstream fix. I'm not claiming a specific remote exploit against Harvester; a crafted reply would have to come from whatever answers DHCP on the VLAN. `go build ./cmd/... ./pkg/...`, `go vet`, and `go test ./pkg/helper/... ./pkg/controller/agent/hostnetworkconfig/...` pass, and the vendor tree was refreshed with `go mod tidy` and `go mod vendor`. One caveat so reviewers aren't surprised: `go build ./...` fails on the repo-root `main.go` both before and after this change, since that file only carries `//go:generate` directives with no `func main`. `scripts/build` compiles the three cmd binaries directly, so nothing new breaks here.
