### PR TITLE
[WIP]Optimize HostNetworkConfig OnChange

### DIFF
--- a/pkg/controller/agent/hostnetworkconfig/controller.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller.go
@@ -72,30 +72,30 @@ func Register(ctx context.Context, management *config.Management) error {
 	return nil
 }
 
-func checkifHostNetworkInterfaceExists(hnc *networkv1.HostNetworkConfig) (bool, error) {
+func checkifHostNetworkInterfaceExists(hnc *networkv1.HostNetworkConfig) (bool, *iface.Link, error) {
 	v, err := vlan.GetVlan(hnc.Spec.ClusterNetwork)
 	if err != nil {
 		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			return false, nil
+			return false, nil, nil
 		}
-		return false, err
+		return false, nil, err
 	}
 
 	bridgelink, err := v.GetBridgelink()
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	vlanIntf := utils.GetClusterNetworkBrVlanDevice(bridgelink.Attrs().Name, hnc.Spec.VlanID)
-	_, err = netlink.LinkByName(vlanIntf)
+	link, err := netlink.LinkByName(vlanIntf)
 	if err != nil {
 		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			return false, nil
+			return false, nil, nil
 		}
-		return false, err
+		return false, nil, err
 	}
 
-	return true, nil
+	return true, iface.NewLink(link), nil
 }
 
 func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*networkv1.HostNetworkConfig, error) {
@@ -110,7 +110,7 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 		return nil, err
 	}
 
-	intfExists, err := checkifHostNetworkInterfaceExists(hnc)
+	intfExists, curLink, err := checkifHostNetworkInterfaceExists(hnc)
 	if err != nil {
 		return nil, err
 	}
@@ -129,52 +129,42 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 		return hnc, nil
 	}
 
-	// node selector matches and host network interface already exists, skip processing
-	if intfExists {
-		logrus.Infof("hostnetwork config %s has been applied on this node already, update nodestatus,tunnel interface annotation and skip", hnc.Name)
-
-		// intf exists but there could be change in underlay, need to update node annotation with new interface if needed
-		if err := h.addNodeAnnotation(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID), hnc.Spec.Underlay); err != nil {
-			return nil, fmt.Errorf("add node annotation to node %s for host network config %s failed, error: %w", h.nodeName, hnc.Name, err)
-		}
-
-		err := h.setHostNetworkPerNodeStatus(hnc, true, nil)
-		if err != nil {
-			return nil, err
-		}
-		return hnc, nil
-	}
-
 	var addr string
 	var bridgelink *iface.Link
 
-	v, err := vlan.GetVlan(hnc.Spec.ClusterNetwork)
-	if err != nil {
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			logrus.Infof("cluster network %s is not set on this node, skip", hnc.Spec.ClusterNetwork)
-			//stop and delete all lease manaagers assosciated with the cluster network (if uplink removed due to vlanconfig changes/deletion)
-			h.stopLeaseManager(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID))
-			return nil, nil
+	// create new interface
+	if !intfExists {
+		v, err := vlan.GetVlan(hnc.Spec.ClusterNetwork)
+		if err != nil {
+			if errors.As(err, &netlink.LinkNotFoundError{}) {
+				logrus.Infof("cluster network %s is not set on this node, skip", hnc.Spec.ClusterNetwork)
+				//stop and delete all lease manaagers assosciated with the cluster network (if uplink removed due to vlanconfig changes/deletion)
+				h.stopLeaseManager(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID))
+				return nil, nil
+			}
+			return hnc, h.updateHostNetworkReadyStatus(hnc, err)
 		}
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
-	}
 
-	bridgelink, err = v.GetBridgelink()
-	if err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
-	}
+		bridgelink, err = v.GetBridgelink()
+		if err != nil {
+			return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+		}
 
-	if err = bridgelink.AddBridgeVlanSelf(hnc.Spec.VlanID); err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
-	}
+		if err = bridgelink.AddBridgeVlanSelf(hnc.Spec.VlanID); err != nil {
+			return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+		}
 
-	if err = bridgelink.CreateVlanSubInterface(hnc.Spec.VlanID); err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
-	}
+		if err = bridgelink.CreateVlanSubInterface(hnc.Spec.VlanID); err != nil {
+			return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+		}
 
-	// reconcile cluster network to add vid to the uplink(cluster-bo)
-	if err := h.wakeUpClusterNetwork(hnc.Spec.ClusterNetwork); err != nil {
-		return nil, fmt.Errorf("wake up cluster network %s failed, error: %w", hnc.Spec.ClusterNetwork, err)
+		// reconcile cluster network to add vid to the uplink(cluster-bo)
+		if err := h.wakeUpClusterNetwork(hnc.Spec.ClusterNetwork); err != nil {
+			return nil, fmt.Errorf("wake up cluster network %s failed, error: %w", hnc.Spec.ClusterNetwork, err)
+		}
+	} else {
+		// reuse existing link for following IP related operations
+		bridgelink = curLink
 	}
 
 	switch hnc.Spec.Mode {

--- a/pkg/network/iface/vlan.go
+++ b/pkg/network/iface/vlan.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/harvester/harvester-network-controller/pkg/utils"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -73,6 +75,7 @@ func (l *Link) DelVlanSubInterface(vid uint16) error {
 		}
 	}
 
+	logrus.Infof("prepare to delete vlan subinterface link: %v, vid: %v", linkName, vid)
 	if err := netlink.LinkDel(vlanLink); err != nil {
 		return fmt.Errorf("delete vlan subinterface failed, error: %v, link: %s, vid: %d", err, linkName, vid)
 	}
@@ -104,6 +107,8 @@ func (l *Link) SetIPAddress(cidr string, vid uint16) error {
 
 	for _, address := range addresses {
 		if !ipAddr.IP.Equal(address.IP) {
+			// essential to emit a log when delete an IP
+			logrus.Infof("prepare to delete stale IP %v from interface %v", address.IP, linkName)
 			if err := netlink.AddrDel(vlanLink, &address); err != nil {
 				return fmt.Errorf("delete ip address failed, error: %v, link: %s, ipNet: %v", err, l.Attrs().Name, address)
 			}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

1. HostNetworkConfig OnChange is shortcutted randomly.

```
if intfExists {
    // BUG: Shortcuts immediately without checking if:
    // 1. hnc.Spec.HostIPs changed to a new IP for this node
    // 2. hnc.Spec.Mode changed from Static to DHCP (or vice versa)
    // 3. the nic was not up on last try
    // 4. ip was not set
    // 5. dhcp failed in the middle

    return hnc, nil
}
```

2. Additional observation: due to the `single object with multi node status` model, it could be affected by any flaky node.

```
[Flaky Node-A] (Interface Flaps / Errors out)
      │
      ├──> Patches status.nodeStatus["Node-A"] (Error state)
      │
      ▼
[K8s API Server] (Emits WATCH event for HostNetworkConfig v123)
      │
      ├───► Broadcasts WATCH event to Node-A
      ├───► Broadcasts WATCH event to Node-B
      ├───► Broadcasts WATCH event to Node-C
      └───► Broadcasts WATCH event to Node-N
      │
      ▼
[All Healthy Nodes (B...N)]
      │
      ├──> Receives WATCH event for Node-A's status change
      ├──> Enters OnChange() blindly (No DeepEqual Guard)
      ├──> Re-executes Netlink / DHCP / IP commands
      ├──> Re-patches status.nodeStatus["Node-X"] to API Server
      │
      ▼
[API Server Storm] (N new WATCH events generated!)
      │
      └───► Loop amplifies exponentially until backoff limit is hit
```


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Ensure the OnChange is idempotent
2. Add a check between local status and CRD status

**Related Issue:**

https://github.com/harvester/harvester/issues/11519

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

