### PR TITLE
fix(webhook): skip self-comparison in validateHostNetworkConfig during updates

### DIFF
--- a/pkg/webhook/hostnetworkconfig/validator.go
+++ b/pkg/webhook/hostnetworkconfig/validator.go
@@ -302,6 +302,11 @@ func (v *Validator) validateHostNetworkConfig(newhnc *networkv1.HostNetworkConfi
 			continue
 		}
 
+		// Skip comparing the CR against itself during updates
+		if hostnetworkconfig.Name == newhnc.Name {
+			continue
+		}
+
 		//no more than one underlay exists for overlay networks. If user has to change underlay setting, old underlay has to be disabled first.
 		if hostnetworkconfig.Spec.Underlay && newhnc.Spec.Underlay {
 			return fmt.Errorf("hostnetworkconfig %s already exists for cluster network %s vlanid %d with underlay enabled", hostnetworkconfig.Name, newhnc.Spec.ClusterNetwork, hostnetworkconfig.Spec.VlanID)
@@ -311,8 +316,10 @@ func (v *Validator) validateHostNetworkConfig(newhnc *networkv1.HostNetworkConfi
 			continue
 		}
 
+		// Enforce VLAN ID uniqueness on creation only to avoid blocking updates on existing duplicate states
 		if op == ValidateCreate && hostnetworkconfig.Spec.VlanID == newhnc.Spec.VlanID {
-			return fmt.Errorf("hostnetworkconfig %s already exists for cluster network %s with vlanID %d", hostnetworkconfig.Name, hostnetworkconfig.Spec.ClusterNetwork, hostnetworkconfig.Spec.VlanID)
+			return fmt.Errorf("hostnetworkconfig %s already exists for cluster network %s with vlanID %d",
+				hostnetworkconfig.Name, hostnetworkconfig.Spec.ClusterNetwork, hostnetworkconfig.Spec.VlanID)
 		}
 	}
 

--- a/pkg/webhook/hostnetworkconfig/validator_test.go
+++ b/pkg/webhook/hostnetworkconfig/validator_test.go
@@ -251,6 +251,10 @@ func TestCreateHostNetworkConfig(t *testing.T) {
 				},
 			},
 			currentHostNetworkConfig: &networkv1.HostNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testHNC-1",
+					Annotations: map[string]string{"test": "test"},
+				},
 				Spec: networkv1.HostNetworkConfigSpec{
 					ClusterNetwork: testCnName,
 					VlanID:         2012,
@@ -259,6 +263,10 @@ func TestCreateHostNetworkConfig(t *testing.T) {
 				},
 			},
 			newHostNetworkConfig: &networkv1.HostNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testHNC-2",
+					Annotations: map[string]string{"test": "test"},
+				},
 				Spec: networkv1.HostNetworkConfigSpec{
 					ClusterNetwork: testCnName,
 					VlanID:         2012,
@@ -310,6 +318,10 @@ func TestCreateHostNetworkConfig(t *testing.T) {
 				},
 			},
 			currentHostNetworkConfig: &networkv1.HostNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testHNC-1",
+					Annotations: map[string]string{"test": "test"},
+				},
 				Spec: networkv1.HostNetworkConfigSpec{
 					ClusterNetwork: testCnName,
 					VlanID:         2012,
@@ -318,6 +330,10 @@ func TestCreateHostNetworkConfig(t *testing.T) {
 				},
 			},
 			newHostNetworkConfig: &networkv1.HostNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testHNC-2",
+					Annotations: map[string]string{"test": "test"},
+				},
 				Spec: networkv1.HostNetworkConfigSpec{
 					ClusterNetwork: testCnName11,
 					VlanID:         2013,
@@ -759,6 +775,91 @@ func TestUpdateHostNetworkConfig(t *testing.T) {
 			},
 		},
 		{
+			name:      "updating HostIPs for same hostnetworkconfig should be allowed",
+			returnErr: false,
+			errKey:    "",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNadName,
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testNadConfig,
+				},
+			},
+			currentNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			currentVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "currentVC",
+					Annotations: map[string]string{utils.KeyMatchedNodes: "[\"node1\"]"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+					Uplink: networkv1.Uplink{
+						LinkAttrs: &networkv1.LinkAttrs{
+							MTU: utils.DefaultMTU,
+						},
+					},
+				},
+			},
+			currentVS: &networkv1.VlanStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        utils.Name("", testCnName, "node1"),
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Status: networkv1.VlStatus{
+					ClusterNetwork: testCnName,
+					VlanConfig:     "currentVC",
+					Conditions: []networkv1.Condition{
+						{
+							Type:   networkv1.Ready,
+							Status: "True",
+						},
+					},
+				},
+			},
+			currentHostNetworkConfig: &networkv1.HostNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testHNC",
+					Annotations: map[string]string{"test": "test"},
+				},
+				Spec: networkv1.HostNetworkConfigSpec{
+					ClusterNetwork: testCnName,
+					VlanID:         2012,
+					Mode:           "static",
+					HostIPs:        map[string]networkv1.IPAddr{"node1": "192.168.1.100/24"},
+					Underlay:       true,
+				},
+			},
+			newHostNetworkConfig: &networkv1.HostNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testHNC",
+					Annotations: map[string]string{"test": "test2"},
+				},
+				Spec: networkv1.HostNetworkConfigSpec{
+					ClusterNetwork: testCnName,
+					VlanID:         2012,
+					Mode:           "static",
+					HostIPs:        map[string]networkv1.IPAddr{"node1": "192.168.2.100/24"},
+					Underlay:       true,
+				},
+			},
+		},
+		{
 			name:      "updating cluster network is not allowed",
 			returnErr: true,
 			errKey:    "cannot update",
@@ -1044,7 +1145,223 @@ func TestUpdateHostNetworkConfig(t *testing.T) {
 			validator := NewHostNetworkConfigValidator(nadCache, cnCache, hncCache, vcCache, vsCache, nodeCache, vmCache)
 
 			err := validator.Update(nil, tc.currentHostNetworkConfig, tc.newHostNetworkConfig)
-			assert.True(t, tc.returnErr == (err != nil))
+			assert.Equal(t, tc.returnErr, err != nil, "unexpected error result: %v", err)
+			if tc.returnErr {
+				assert.NotNil(t, err)
+				assert.True(t, strings.Contains(err.Error(), tc.errKey))
+			}
+		})
+	}
+}
+
+// Test that updating an existing HostNetworkConfig succeeds even if the cluster
+// contains a legacy duplicate VlanID (ensures op == ValidateCreate guard prevents false positives).
+func TestUpdateHostNetworkConfigWithMultipleCacheObjects(t *testing.T) {
+	tests := []struct {
+		name                      string
+		returnErr                 bool
+		errKey                    string
+		currentCN                 *networkv1.ClusterNetwork
+		currentVC                 *networkv1.VlanConfig
+		currentVS                 *networkv1.VlanStatus
+		currentNAD                *cniv1.NetworkAttachmentDefinition
+		currentHostNetworkConfigs []*networkv1.HostNetworkConfig
+		oldHostNetworkConfig      *networkv1.HostNetworkConfig
+		newHostNetworkConfig      *networkv1.HostNetworkConfig
+		currentNode               *v1.Node
+		currentNode2              *v1.Node
+		currentVM                 *kubevirtv1.VirtualMachine
+	}{
+		{
+			name:      "updating testHNC1 in a cluster with legacy duplicate VlanID on testHNC2 should succeed",
+			returnErr: false,
+			errKey:    "",
+			currentCN: &networkv1.ClusterNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testCnName,
+					Annotations: map[string]string{"test": "test"},
+				},
+			},
+			currentNAD: &cniv1.NetworkAttachmentDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testNadName,
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: cniv1.NetworkAttachmentDefinitionSpec{
+					Config: testNadConfig,
+				},
+			},
+			currentNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			currentVC: &networkv1.VlanConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "currentVC",
+					Annotations: map[string]string{utils.KeyMatchedNodes: "[\"node1\"]"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Spec: networkv1.VlanConfigSpec{
+					ClusterNetwork: testCnName,
+					Uplink: networkv1.Uplink{
+						LinkAttrs: &networkv1.LinkAttrs{
+							MTU: utils.DefaultMTU,
+						},
+					},
+				},
+			},
+			currentVS: &networkv1.VlanStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        utils.Name("", testCnName, "node1"),
+					Annotations: map[string]string{"test": "test"},
+					Labels:      map[string]string{utils.KeyClusterNetworkLabel: testCnName},
+				},
+				Status: networkv1.VlStatus{
+					ClusterNetwork: testCnName,
+					VlanConfig:     "currentVC",
+					Conditions: []networkv1.Condition{
+						{
+							Type:   networkv1.Ready,
+							Status: "True",
+						},
+					},
+				},
+			},
+			// Pre-existing cache state containing both duplicate HNCs (legacy state)
+			currentHostNetworkConfigs: []*networkv1.HostNetworkConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "testHNC1",
+						Annotations: map[string]string{"test": "v1"},
+					},
+					Spec: networkv1.HostNetworkConfigSpec{
+						ClusterNetwork: testCnName,
+						VlanID:         2012,
+						Mode:           "static",
+						HostIPs:        map[string]networkv1.IPAddr{"node1": "192.168.1.100/24"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "testHNC2",
+						Annotations: map[string]string{"test": "v1"},
+					},
+					Spec: networkv1.HostNetworkConfigSpec{
+						ClusterNetwork: testCnName,
+						VlanID:         2012, // Legacy duplicate VlanID due to known reasons
+						Mode:           "static",
+						HostIPs:        map[string]networkv1.IPAddr{"node1": "192.168.2.100/24"},
+					},
+				},
+			},
+
+			// The old object target being updated
+			oldHostNetworkConfig: &networkv1.HostNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testHNC1",
+					Annotations: map[string]string{"test": "v1"},
+				},
+				Spec: networkv1.HostNetworkConfigSpec{
+					ClusterNetwork: testCnName,
+					VlanID:         2012,
+					Mode:           "static",
+					HostIPs:        map[string]networkv1.IPAddr{"node1": "192.168.1.100/24"},
+				},
+			},
+			// The updated object target
+			newHostNetworkConfig: &networkv1.HostNetworkConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testHNC1",
+					Annotations: map[string]string{"test": "v2"},
+				},
+				Spec: networkv1.HostNetworkConfigSpec{
+					ClusterNetwork: testCnName,
+					VlanID:         2012,
+					Mode:           "static",
+					HostIPs:        map[string]networkv1.IPAddr{"node1": "192.168.3.100/24"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			assert.NotNil(t, tc.newHostNetworkConfig)
+			if tc.newHostNetworkConfig == nil {
+				return
+			}
+
+			assert.NotNil(t, tc.oldHostNetworkConfig)
+			if tc.oldHostNetworkConfig == nil {
+				return
+			}
+
+			nchclientset := fake.NewSimpleClientset()
+			vmCache := fakeclients.VirtualMachineCache(nchclientset.KubevirtV1().VirtualMachines)
+			nadCache := fakeclients.NetworkAttachmentDefinitionCache(nchclientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
+			hncCache := fakeclients.HostNetworkConfigCache(nchclientset.NetworkV1beta1().HostNetworkConfigs)
+
+			// client to inject test data
+			vcClient := fakeclients.VlanConfigClient(nchclientset.NetworkV1beta1().VlanConfigs)
+			vsClient := fakeclients.VlanStatusClient(nchclientset.NetworkV1beta1().VlanStatuses)
+			cnClient := fakeclients.ClusterNetworkClient(nchclientset.NetworkV1beta1().ClusterNetworks)
+			nodeClient := fakeclients.NodeClient(nchclientset.CoreV1().Nodes)
+			cnCache := fakeclients.ClusterNetworkCache(nchclientset.NetworkV1beta1().ClusterNetworks)
+			vcCache := fakeclients.VlanConfigCache(nchclientset.NetworkV1beta1().VlanConfigs)
+			vsCache := fakeclients.VlanStatusCache(nchclientset.NetworkV1beta1().VlanStatuses)
+			nodeCache := fakeclients.NodeCache(nchclientset.CoreV1().Nodes)
+
+			if tc.currentVC != nil {
+				_, err := vcClient.Create(tc.currentVC)
+				assert.NoError(t, err)
+			}
+			if tc.currentCN != nil {
+				_, err := cnClient.Create(tc.currentCN)
+				assert.NoError(t, err)
+			}
+			if tc.currentVS != nil {
+				_, err := vsClient.Create(tc.currentVS)
+				assert.NoError(t, err)
+			}
+			if tc.currentNode != nil {
+				_, err := nodeClient.Create(tc.currentNode)
+				assert.NoError(t, err)
+			}
+			if tc.currentNode2 != nil {
+				_, err := nodeClient.Create(tc.currentNode2)
+				assert.NoError(t, err)
+			}
+
+			if tc.currentVM != nil {
+				err := nchclientset.Tracker().Add(tc.currentVM)
+				assert.Nil(t, err, "mock resource vm should add into fake controller tracker")
+			}
+
+			if tc.currentNAD != nil {
+				nadGvr := schema.GroupVersionResource{
+					Group:    "k8s.cni.cncf.io",
+					Version:  "v1",
+					Resource: "network-attachment-definitions",
+				}
+
+				if err := nchclientset.Tracker().Create(nadGvr, tc.currentNAD.DeepCopy(), tc.currentNAD.Namespace); err != nil {
+					t.Fatalf("failed to add nad %+v", tc.currentNAD)
+				}
+			}
+			hncClient := fakeclients.HostNetworkConfigClient(nchclientset.NetworkV1beta1().HostNetworkConfigs)
+			for _, hnc := range tc.currentHostNetworkConfigs {
+				_, err := hncClient.Create(hnc)
+				assert.NoError(t, err)
+			}
+
+			validator := NewHostNetworkConfigValidator(nadCache, cnCache, hncCache, vcCache, vsCache, nodeCache, vmCache)
+
+			err := validator.Update(nil, tc.oldHostNetworkConfig, tc.newHostNetworkConfig)
+			assert.Equal(t, tc.returnErr, err != nil, "unexpected error result: %v", err)
 			if tc.returnErr {
 				assert.NotNil(t, err)
 				assert.True(t, strings.Contains(err.Error(), tc.errKey))


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

During an Update operation on an existing HostNetworkConfig (HNC), the admission webhook's validation logic (validateHostNetworkConfig) iterates over all cached HNC objects to check for duplicate underlay configurations and (ClusterNetwork, VlanID) collisions.

Because the cache contains the pre-update version of the CR being modified, the loop compares the updated CR against itself (hostnetworkconfig.Name == newhnc.Name). This results in false-positive validation errors:

Updating non-immutable fields on an existing Underlay: true HNC is erroneously rejected because hostnetworkconfig.Spec.Underlay && newhnc.Spec.Underlay evaluates to true.

Any general update validation encounters self-collision on (ClusterNetwork, VlanID).

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add an explicit name check if hostnetworkconfig.Name == newhnc.Name { continue } inside validateHostNetworkConfig to skip self-comparison during update operations.

**Related Issue:**

https://github.com/harvester/harvester/issues/11603

observed while working on the main PR https://github.com/harvester/network-controller-harvester/pull/382

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Original issue:
<img width="2234" height="184" alt="image" src="https://github.com/user-attachments/assets/f21f4d79-4eab-4968-a54c-a7933637dfd9" />




(1) Create an underlay mode hostnetworkconfig, then change the host ip, it is denied on old webhook, but allowed after the fix.
<img width="2052" height="1254" alt="image" src="https://github.com/user-attachments/assets/2a69ddf4-c72a-48e3-a245-7eb165346f3e" />

(2) Change the IP.
```
apiVersion: v1
items:
- apiVersion: network.harvesterhci.io/v1beta1
  kind: HostNetworkConfig
  metadata:
    creationTimestamp: "2026-09-08T10:09:51Z"
    finalizers:
    - wrangler.cattle.io/harvester-network-hostnetworkconfig-controller
    generation: 4
    name: hnc1
    resourceVersion: "718905"
    uid: ffa45d51-624f-43df-80bd-0da6a2ce05ef
  spec:
    clusterNetwork: mgmt
    ips:
      harv31: 192.168.3.11/24  // webhook does not block this change
    mode: static
    underlay: true
    vlanID: 3
  status:
    nodeStatus:
      harv31:
        clusterNetwork: mgmt
        conditions:
        - message: ""
          status: "True"
          type: ready
        mode: static
        vlanID: 3
kind: List
metadata:
  resourceVersion: ""
```

Note: The IP out-of-sync is booked on https://github.com/harvester/harvester/issues/11618. It will be sovled via PR https://github.com/harvester/network-controller-harvester/pull/395 and validated per issue 11618.

IP was not updated on node yet.
```
79: mgmt-br.3@mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 52:54:00:c1:9d:05 brd ff:ff:ff:ff:ff:ff
    inet 192.168.3.10/24 brd 192.168.3.255 scope global mgmt-br.3
       valid_lft forever preferred_lft forever
```