### PR TITLE
[WIP] Refactor(agent): introduce local state caching for efficient, idempotent hostnetwork reconciliation

### DIFF
--- a/pkg/controller/agent/hostnetworkconfig/controller.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller.go
@@ -54,6 +54,7 @@ func Register(ctx context.Context, management *config.Management) error {
 	var err error
 
 	ttl := getTTLFromEnvOrDefault()
+	disabled := getDisableFromEnvOrDefault()
 
 	handler := &Handler{
 		nodeName:          management.Options.NodeName,
@@ -64,8 +65,10 @@ func Register(ctx context.Context, management *config.Management) error {
 		cnCache:           cns.Cache(),
 		cnController:      cns,
 		leaseManagers:     make(map[string]*LeaseManager),
-		stateMgr:          NewLocalHostNetworkConfigStateManager(ttl),
+		stateMgr:          NewLocalHostNetworkConfigStateManager(ttl, disabled),
 	}
+
+	logrus.Infof("Node %s stateMgr initialized: %s", handler.nodeName, handler.stateMgr.String())
 
 	if mgmtIntf, err = iface.GetMgmtInterface(); err != nil {
 		return fmt.Errorf("failed to get management interface for node %s, error: %w", handler.nodeName, err)
@@ -94,10 +97,17 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 
 	logrus.Infof("hostnetwork config %s is changed, spec: %+v", hnc.Name, hnc.Spec)
 
-	targetHash, err := utils.ComputeSpecHash(hnc.Spec)
-	if err != nil {
-		logrus.Debugf("failed to compute target spec hash for hostnetwork config %s, falling back to full process: %v", hnc.Name, err)
-		targetHash = ""
+	var targetHash string
+	var err error
+	// Skip hash computation when the state manager is disabled to save CPU cycles.
+	// When targetHash remains empty (""), all downstream state checks (IsReady/IsRemoved)
+	// immediately evaluate to false and safely fall back to full reconciliation.
+	if !h.stateMgr.Disabled() {
+		targetHash, err = utils.ComputeSpecHash(hnc.Spec)
+		if err != nil {
+			logrus.Debugf("failed to compute target spec hash for hostnetwork config %s, falling back to full process: %v", hnc.Name, err)
+			targetHash = ""
+		}
 	}
 
 	matchNodeSet, err := h.matchNode(hnc.Spec.NodeSelector)

--- a/pkg/controller/agent/hostnetworkconfig/controller.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller.go
@@ -68,12 +68,12 @@ func Register(ctx context.Context, management *config.Management) error {
 		stateMgr:          NewLocalHostNetworkConfigStateManager(ttl, disabled),
 	}
 
-	logrus.Infof("Node %s stateMgr initialized: %s", handler.nodeName, handler.stateMgr.String())
-
 	if mgmtIntf, err = iface.GetMgmtInterface(); err != nil {
 		return fmt.Errorf("failed to get management interface for node %s, error: %w", handler.nodeName, err)
 	}
 	handler.mgmtIntfName = mgmtIntf
+
+	logrus.Infof("Node %s, mgmt interface %s, stateMgr initialized: %s", handler.nodeName, mgmtIntf, handler.stateMgr.String())
 
 	hns.OnChange(ctx, ControllerName, handler.OnChange)
 	hns.OnRemove(ctx, ControllerName, handler.OnRemove)
@@ -126,7 +126,6 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 	if h.isAlreadyReady(hnc, targetHash) {
 		// update node annotation to set the vlan sub interface to be used as underlay (if underlay is enabled)
 		// and set to default mgmt interface if underlay is not enabled
-
 		if err := h.addNodeAnnotation(intfName, hnc.Spec.Underlay); err != nil {
 			return nil, fmt.Errorf("add node annotation to node %s for host network config %s failed, error: %w", h.nodeName, hnc.Name, err)
 		}
@@ -256,7 +255,7 @@ func (h *Handler) removeHostNetworkInterface(hnc *networkv1.HostNetworkConfig, o
 		return nil, fmt.Errorf("wake up cluster network %s failed, error: %w", hnc.Spec.ClusterNetwork, err)
 	}
 
-	// 5. Update per-node status nodestatus when interface deleted due to node selector changes.
+	// 5. Update per-node status when interface deleted due to node selector changes.
 	if onChange {
 		if err := h.removeHostNetworkPerNodeStatus(hnc); err != nil {
 			return nil, err
@@ -273,7 +272,7 @@ func (h *Handler) OnRemove(_ string, hnc *networkv1.HostNetworkConfig) (*network
 
 	logrus.Infof("hostnetwork config %s has been removed, spec: %+v", hnc.Name, hnc.Spec)
 
-	// OnRemove deletes the entry from the local cache unconditionally.
+	// Delete local state tracking entry when the CRD is being removed.
 	h.stateMgr.Delete(hnc.Name)
 
 	return h.removeHostNetworkInterface(hnc, false)

--- a/pkg/controller/agent/hostnetworkconfig/controller.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller.go
@@ -41,6 +41,8 @@ type Handler struct {
 	mu            sync.Mutex
 	leaseManagers map[string]*LeaseManager
 	mgmtIntfName  string
+
+	stateMgr *LocalHostNetworkConfigStateManager
 }
 
 func Register(ctx context.Context, management *config.Management) error {
@@ -49,6 +51,8 @@ func Register(ctx context.Context, management *config.Management) error {
 	cns := management.HarvesterNetworkFactory.Network().V1beta1().ClusterNetwork()
 	var mgmtIntf string
 	var err error
+
+	ttl := getTTLFromEnvOrDefault()
 
 	handler := &Handler{
 		nodeName:          management.Options.NodeName,
@@ -59,6 +63,7 @@ func Register(ctx context.Context, management *config.Management) error {
 		cnCache:           cns.Cache(),
 		cnController:      cns,
 		leaseManagers:     make(map[string]*LeaseManager),
+		stateMgr:          NewLocalHostNetworkConfigStateManager(ttl),
 	}
 
 	if mgmtIntf, err = iface.GetMgmtInterface(); err != nil {

--- a/pkg/controller/agent/hostnetworkconfig/controller.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller.go
@@ -150,8 +150,8 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 	if err != nil {
 		// hand over to framework to retry
 		logrus.Infof("cluster network %s is not set on this node, something might be wrong", hnc.Spec.ClusterNetwork)
-		//stop and delete all lease manaagers assosciated with the cluster network (if uplink removed due to vlanconfig changes/deletion)
-		// h.stopLeaseManager(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID))
+		// Stop and delete the lease manager associated with this VLAN interface (if any) to avoid orphaned DHCP goroutines.
+		h.cleanupLeaseManager(hnc)
 		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL2NotReady)
 	}
 
@@ -182,7 +182,7 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 
 	case IPModeStatic:
 		// stop lease manager if exists (previously in dhcp mode)
-		h.stopLeaseManager(utils.GetClusterNetworkBrVlanDevice(bridgelink.Attrs().Name, hnc.Spec.VlanID))
+		h.cleanupLeaseManager(hnc)
 
 		if addr, err = findMatchingIPfromNode(h.nodeName, hnc.Spec.HostIPs); err != nil {
 			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL3NotReady)
@@ -217,7 +217,7 @@ func (h *Handler) updateHostNetworkReadyStatus(hnc *networkv1.HostNetworkConfig,
 	if statusUpdateErr := h.setHostNetworkStatus(hnc, l3setupErr, categoryErr); statusUpdateErr != nil {
 		// Mark cache as Unknown if status update fails
 		h.stateMgr.CreateOrUpdate(hnc.Name, NewLocalHostNetworkConfigState(targetHash, StateUnknown))
-		return fmt.Errorf("set host network %s ready (%v) failed [%w], error: %w configErr: %w", hnc.Name, l3setupErr == nil, categoryErr, statusUpdateErr, l3setupErr)
+		return fmt.Errorf("set host network %s ready (%t) failed [category=%v]: %w (setupErr=%v)", hnc.Name, l3setupErr == nil, categoryErr, statusUpdateErr, l3setupErr)
 	}
 
 	if l3setupErr != nil {
@@ -235,6 +235,7 @@ func (h *Handler) removeHostNetworkInterface(hnc *networkv1.HostNetworkConfig, o
 	v, err := vlan.GetVlan(hnc.Spec.ClusterNetwork)
 	if err != nil {
 		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			h.cleanupLeaseManager(hnc)
 			logrus.Infof("cluster network %s is not set on this node, skip", hnc.Spec.ClusterNetwork)
 			return nil, nil
 		}
@@ -244,6 +245,7 @@ func (h *Handler) removeHostNetworkInterface(hnc *networkv1.HostNetworkConfig, o
 	bridgelink, err := v.GetBridgelink()
 	if err != nil {
 		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			h.cleanupLeaseManager(hnc)
 			return nil, nil
 		} else {
 			return nil, fmt.Errorf("failed to get link for bridge %s, error: %w", v.Bridge().Name, err)
@@ -251,7 +253,7 @@ func (h *Handler) removeHostNetworkInterface(hnc *networkv1.HostNetworkConfig, o
 	}
 
 	// 1. Stop lease manager first to release sockets and terminate DHCP process on the sub-interface
-	h.stopLeaseManager(utils.GetClusterNetworkBrVlanDevice(bridgelink.Attrs().Name, hnc.Spec.VlanID))
+	h.cleanupLeaseManager(hnc)
 
 	// 2. Remove VLAN sub-interface
 	if err := bridgelink.DelVlanSubInterface(hnc.Spec.VlanID); err != nil {
@@ -266,13 +268,6 @@ func (h *Handler) removeHostNetworkInterface(hnc *networkv1.HostNetworkConfig, o
 	// 4. Reconcile cluster network to delete vid from the uplink(cluster-bo)
 	if err := h.wakeUpClusterNetwork(hnc.Spec.ClusterNetwork); err != nil {
 		return nil, fmt.Errorf("wake up cluster network %s failed, error: %w", hnc.Spec.ClusterNetwork, err)
-	}
-
-	// 5. Update per-node status when interface deleted due to node selector changes.
-	if onChange {
-		if err := h.removeHostNetworkPerNodeStatus(hnc); err != nil {
-			return nil, err
-		}
 	}
 
 	return hnc, nil
@@ -332,7 +327,7 @@ func (h *Handler) removeHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfi
 
 	patchBytes, err := json.Marshal(patchPayload)
 	if err != nil {
-		return fmt.Errorf("failed to marshal patch payload: %w", err)
+		return fmt.Errorf("removeHostNetworkPerNodeStatus failed to marshal patch payload: %w", err)
 	}
 
 	_, err = h.hostNetworkClient.Patch(
@@ -342,7 +337,7 @@ func (h *Handler) removeHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfi
 		"status",
 	)
 	if err != nil {
-		return fmt.Errorf("failed to patch HostNetworkConfig status for node %s: %w", h.nodeName, err)
+		return fmt.Errorf("removeHostNetworkPerNodeStatus failed to patch status for node %s: %w", h.nodeName, err)
 	}
 
 	return nil
@@ -405,6 +400,16 @@ func (h *Handler) setHostNetworkStatus(hnc *networkv1.HostNetworkConfig, setupEr
 	}
 
 	return h.setHostNetworkPerNodeStatus(hnc, true, nil, categoryErr)
+}
+
+// cleanupLeaseManager stops the lease manager unconditionally for the given HostNetworkConfig
+// to prevent resource or background goroutine leaks.
+// note: This will later be restricted exclusively to DHCP mode HNCs once HNC mode changes are disallowed.
+func (h *Handler) cleanupLeaseManager(hnc *networkv1.HostNetworkConfig) {
+	if hnc == nil {
+		return
+	}
+	h.stopLeaseManager(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID))
 }
 
 func (h *Handler) stopLeaseManager(vlanIntfName string) {
@@ -535,6 +540,11 @@ func (h *Handler) handleNonMatchingNode(hnc *networkv1.HostNetworkConfig, target
 
 	// Teardown netlink interface and patch node status
 	if _, err := h.removeHostNetworkInterface(hnc, true); err != nil {
+		return nil, err
+	}
+
+	// Update per-node status when interface deleted due to node selector changes.
+	if err := h.removeHostNetworkPerNodeStatus(hnc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/agent/hostnetworkconfig/controller.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -77,32 +78,15 @@ func Register(ctx context.Context, management *config.Management) error {
 	return nil
 }
 
-func checkifHostNetworkInterfaceExists(hnc *networkv1.HostNetworkConfig) (bool, error) {
-	v, err := vlan.GetVlan(hnc.Spec.ClusterNetwork)
-	if err != nil {
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	bridgelink, err := v.GetBridgelink()
-	if err != nil {
-		return false, err
-	}
-
-	vlanIntf := utils.GetClusterNetworkBrVlanDevice(bridgelink.Attrs().Name, hnc.Spec.VlanID)
-	_, err = netlink.LinkByName(vlanIntf)
-	if err != nil {
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
-}
-
+// OnChange handles creation, updates, and deletion events for HostNetworkConfig.
+//
+// Note: Although peer controllers may update the `utils.KeyMatchedNodes` annotation
+// on HNC (triggering OnChange), this handler evaluates node matching dynamically
+// via h.matchNode() rather than relying on that annotation.
+//
+// Hence, the local spec-based target hash remains robust: reconciliation state is
+// strictly governed by the spec content paired with the local cache and CRD status checks
+// (isAlreadyReady / isAlreadyRemoved) rather than dynamic metadata annotations.
 func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*networkv1.HostNetworkConfig, error) {
 	if hnc == nil || hnc.DeletionTimestamp != nil {
 		return nil, nil
@@ -110,71 +94,61 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 
 	logrus.Infof("hostnetwork config %s is changed, spec: %+v", hnc.Name, hnc.Spec)
 
-	matchNodeSet, err := h.matchNode(hnc.Spec.NodeSelector)
+	targetHash, err := utils.ComputeSpecHash(hnc.Spec)
 	if err != nil {
-		return nil, err
+		logrus.Debugf("failed to compute target spec hash for hostnetwork config %s, falling back to full process: %v", hnc.Name, err)
+		targetHash = ""
 	}
 
-	intfExists, err := checkifHostNetworkInterfaceExists(hnc)
+	matchNodeSet, err := h.matchNode(hnc.Spec.NodeSelector)
 	if err != nil {
 		return nil, err
 	}
 
 	// node selector doesn't match, need to clean up the host network config if exists
 	if !matchNodeSet {
-		if intfExists {
-			return h.removeHostNetworkInterface(hnc, true)
-		}
-
-		// always ensure the status is cleaned
-		err := h.removeHostNetworkPerNodeStatus(hnc)
-		if err != nil {
-			return nil, err
-		}
-		return hnc, nil
+		return h.handleNonMatchingNode(hnc, targetHash)
 	}
 
-	// node selector matches and host network interface already exists, skip processing
-	if intfExists {
-		logrus.Infof("hostnetwork config %s has been applied on this node already, update nodestatus,tunnel interface annotation and skip", hnc.Name)
+	intfName := utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID)
 
-		// intf exists but there could be change in underlay, need to update node annotation with new interface if needed
-		if err := h.addNodeAnnotation(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID), hnc.Spec.Underlay); err != nil {
+	// node selector matches, when fully ready, return quickly
+	if h.isAlreadyReady(hnc, targetHash) {
+		// update node annotation to set the vlan sub interface to be used as underlay (if underlay is enabled)
+		// and set to default mgmt interface if underlay is not enabled
+
+		if err := h.addNodeAnnotation(intfName, hnc.Spec.Underlay); err != nil {
 			return nil, fmt.Errorf("add node annotation to node %s for host network config %s failed, error: %w", h.nodeName, hnc.Name, err)
 		}
 
-		err := h.setHostNetworkPerNodeStatus(hnc, true, nil)
-		if err != nil {
-			return nil, err
-		}
+		logrus.Debugf("hostnetwork config %s is already setup and ready on node %s, fast exit", hnc.Name, h.nodeName)
 		return hnc, nil
 	}
 
+	// run the setup process from the beginning
 	var addr string
 	var bridgelink *iface.Link
 
 	v, err := vlan.GetVlan(hnc.Spec.ClusterNetwork)
 	if err != nil {
-		if errors.As(err, &netlink.LinkNotFoundError{}) {
-			logrus.Infof("cluster network %s is not set on this node, skip", hnc.Spec.ClusterNetwork)
-			//stop and delete all lease manaagers assosciated with the cluster network (if uplink removed due to vlanconfig changes/deletion)
-			h.stopLeaseManager(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID))
-			return nil, nil
-		}
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+		// hand over to framework to retry
+		logrus.Infof("cluster network %s is not set on this node, something might be wrong", hnc.Spec.ClusterNetwork)
+		//stop and delete all lease manaagers assosciated with the cluster network (if uplink removed due to vlanconfig changes/deletion)
+		// h.stopLeaseManager(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID))
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
 	}
 
 	bridgelink, err = v.GetBridgelink()
 	if err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
 	}
 
 	if err = bridgelink.AddBridgeVlanSelf(hnc.Spec.VlanID); err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
 	}
 
 	if err = bridgelink.CreateVlanSubInterface(hnc.Spec.VlanID); err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
 	}
 
 	// reconcile cluster network to add vid to the uplink(cluster-bo)
@@ -185,7 +159,7 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 	switch hnc.Spec.Mode {
 	case IPModeDHCP:
 		if err = h.startLeaseManager(bridgelink, hnc.Spec.VlanID); err != nil {
-			return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
 		}
 
 	case IPModeStatic:
@@ -193,40 +167,45 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 		h.stopLeaseManager(utils.GetClusterNetworkBrVlanDevice(bridgelink.Attrs().Name, hnc.Spec.VlanID))
 
 		if addr, err = findMatchingIPfromNode(h.nodeName, hnc.Spec.HostIPs); err != nil {
-			return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
 		}
 
 		if err := bridgelink.SetIPAddress(addr, hnc.Spec.VlanID); err != nil {
-			return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
 		}
 	default:
 		err = fmt.Errorf("unsupported ip assignment mode %s for host network config %s", hnc.Spec.Mode, hnc.Name)
-		return hnc, h.updateHostNetworkReadyStatus(hnc, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
 	}
 
 	//success case, update host network config status to ready
-	if updateErr := h.updateHostNetworkReadyStatus(hnc, nil); updateErr != nil {
+	if updateErr := h.updateHostNetworkReadyStatus(hnc, targetHash, nil); updateErr != nil {
 		return hnc, updateErr
 	}
 
 	// update node annotation to set the vlan sub interface to be used as underlay (if underlay is enabled)
 	// and set to default mgmt interface if underlay is not enabled
-	if err := h.addNodeAnnotation(utils.GetClusterNetworkBrVlanDevice(bridgelink.Attrs().Name, hnc.Spec.VlanID), hnc.Spec.Underlay); err != nil {
+	if err := h.addNodeAnnotation(intfName, hnc.Spec.Underlay); err != nil {
 		return nil, fmt.Errorf("add node annotation to node %s for host network config %s failed, error: %w", h.nodeName, hnc.Name, err)
 	}
 
 	return hnc, nil
 }
 
-func (h *Handler) updateHostNetworkReadyStatus(hnc *networkv1.HostNetworkConfig, l3setupErr error) error {
+func (h *Handler) updateHostNetworkReadyStatus(hnc *networkv1.HostNetworkConfig, targetHash string, l3setupErr error) error {
 	if statusUpdateErr := h.setHostNetworkStatus(hnc, l3setupErr); statusUpdateErr != nil {
-		return fmt.Errorf("set host network %s unready failed, error: %w configErr: %v", hnc.Name, statusUpdateErr, l3setupErr)
+		// Mark cache as Unknown if status update fails
+		h.stateMgr.CreateOrUpdate(hnc.Name, NewLocalHostNetworkConfigState(targetHash, StateUnknown))
+		return fmt.Errorf("set host network %s ready (%v) failed, error: %w configErr: %v", hnc.Name, l3setupErr == nil, statusUpdateErr, l3setupErr)
 	}
 
 	if l3setupErr != nil {
+		h.stateMgr.CreateOrUpdate(hnc.Name, NewLocalHostNetworkConfigState(targetHash, StateUnknown))
 		return fmt.Errorf("setup host network config %s failed, error: %w", hnc.Name, l3setupErr)
 	}
 
+	// per node status is ready
+	h.stateMgr.CreateOrUpdate(hnc.Name, NewLocalHostNetworkConfigState(targetHash, StateReady))
 	return nil
 }
 
@@ -249,22 +228,25 @@ func (h *Handler) removeHostNetworkInterface(hnc *networkv1.HostNetworkConfig, o
 		}
 	}
 
-	if err := bridgelink.DelBridgeVlanSelf(hnc.Spec.VlanID); err != nil {
-		return nil, fmt.Errorf("del bridge vlanconfig %d failed for %s, error: %w", hnc.Spec.VlanID, v.Bridge().Name, err)
-	}
-
+	// 1. Stop lease manager first to release sockets and terminate DHCP process on the sub-interface
 	h.stopLeaseManager(utils.GetClusterNetworkBrVlanDevice(bridgelink.Attrs().Name, hnc.Spec.VlanID))
 
+	// 2. Remove VLAN sub-interface
 	if err := bridgelink.DelVlanSubInterface(hnc.Spec.VlanID); err != nil {
 		return nil, fmt.Errorf("del vlan subinterface %d failed for %s, error: %w", hnc.Spec.VlanID, v.Bridge().Name, err)
 	}
 
-	// reconcile cluster network to delete vid from the uplink(cluster-bo)
+	// 3. Remove bridge VLAN entry
+	if err := bridgelink.DelBridgeVlanSelf(hnc.Spec.VlanID); err != nil {
+		return nil, fmt.Errorf("del bridge vlanconfig %d failed for %s, error: %w", hnc.Spec.VlanID, v.Bridge().Name, err)
+	}
+
+	// 4. Reconcile cluster network to delete vid from the uplink(cluster-bo)
 	if err := h.wakeUpClusterNetwork(hnc.Spec.ClusterNetwork); err != nil {
 		return nil, fmt.Errorf("wake up cluster network %s failed, error: %w", hnc.Spec.ClusterNetwork, err)
 	}
 
-	//update nodestatus when interface deleted due to node selector changes.
+	// 5. Update per-node status nodestatus when interface deleted due to node selector changes.
 	if onChange {
 		if err := h.removeHostNetworkPerNodeStatus(hnc); err != nil {
 			return nil, err
@@ -280,6 +262,9 @@ func (h *Handler) OnRemove(_ string, hnc *networkv1.HostNetworkConfig) (*network
 	}
 
 	logrus.Infof("hostnetwork config %s has been removed, spec: %+v", hnc.Name, hnc.Spec)
+
+	// OnRemove deletes the entry from the local cache unconditionally.
+	h.stateMgr.Delete(hnc.Name)
 
 	return h.removeHostNetworkInterface(hnc, false)
 }
@@ -314,6 +299,7 @@ func (h *Handler) removeHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfi
 		return nil
 	}
 
+	// JSON Merge Patch (RFC 7396): setting a map key to null removes it from the map
 	patchPayload := map[string]interface{}{
 		"status": map[string]interface{}{
 			"nodeStatus": map[string]interface{}{
@@ -324,7 +310,7 @@ func (h *Handler) removeHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfi
 
 	patchBytes, err := json.Marshal(patchPayload)
 	if err != nil {
-		return fmt.Errorf("failed to marshal patch: %w", err)
+		return fmt.Errorf("failed to marshal patch payload: %w", err)
 	}
 
 	_, err = h.hostNetworkClient.Patch(
@@ -341,6 +327,13 @@ func (h *Handler) removeHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfi
 }
 
 func (h *Handler) setHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfig, ready bool, setupErr error) error {
+	readyStatus := "True"
+	message := ""
+	if !ready {
+		readyStatus = "False"
+		message = fmt.Sprintf("setup l3 connectivity failed: %v", setupErr)
+	}
+
 	patchPayload := map[string]interface{}{
 		"status": map[string]interface{}{
 			"nodeStatus": map[string]interface{}{
@@ -350,21 +343,9 @@ func (h *Handler) setHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfig, 
 					"mode":           hnc.Spec.Mode,
 					"conditions": []map[string]interface{}{
 						{
-							"type": networkv1.Ready,
-							"status": func() string {
-								if ready {
-									return "True"
-								} else {
-									return "False"
-								}
-							}(),
-							"message": func() string {
-								if ready {
-									return ""
-								} else {
-									return fmt.Sprintf("setup l3 connectivity failed: %v", setupErr)
-								}
-							}(),
+							"type":    networkv1.Ready,
+							"status":  readyStatus,
+							"message": message,
 						},
 					},
 				},
@@ -393,9 +374,9 @@ func (h *Handler) setHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfig, 
 func (h *Handler) setHostNetworkStatus(hnc *networkv1.HostNetworkConfig, setupErr error) error {
 	if setupErr != nil {
 		return h.setHostNetworkPerNodeStatus(hnc, false, setupErr)
-	} else {
-		return h.setHostNetworkPerNodeStatus(hnc, true, nil)
 	}
+
+	return h.setHostNetworkPerNodeStatus(hnc, true, nil)
 }
 
 func (h *Handler) stopLeaseManager(vlanIntfName string) {
@@ -516,4 +497,64 @@ func (h *Handler) matchNode(nodeSelector *metav1.LabelSelector) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (h *Handler) handleNonMatchingNode(hnc *networkv1.HostNetworkConfig, targetHash string) (*networkv1.HostNetworkConfig, error) {
+	if h.isAlreadyRemoved(hnc, targetHash) {
+		logrus.Debugf("hostnetwork config %s is already removed on node %s, fast exit", hnc.Name, h.nodeName)
+		return hnc, nil
+	}
+
+	// Teardown netlink interface and patch node status
+	if _, err := h.removeHostNetworkInterface(hnc, true); err != nil {
+		return nil, err
+	}
+
+	// Cache is updated to StateRemoved on success
+	h.stateMgr.CreateOrUpdate(hnc.Name, NewLocalHostNetworkConfigState(targetHash, StateRemoved))
+
+	return hnc, nil
+}
+
+func (h *Handler) isAlreadyRemoved(hnc *networkv1.HostNetworkConfig, targetHash string) bool {
+	// 1. Check local state cache
+	localState, exists := h.stateMgr.Get(hnc.Name)
+	if !exists || !localState.IsRemoved(targetHash, h.stateMgr.TTL()) {
+		return false
+	}
+
+	// 2. Check remote CRD status: nodeStatus for this node must be cleared
+	if hnc == nil || hnc.Status.NodeStatus == nil {
+		return true
+	}
+
+	_, statusExists := hnc.Status.NodeStatus[h.nodeName]
+	return !statusExists
+}
+
+func (h *Handler) isAlreadyReady(hnc *networkv1.HostNetworkConfig, targetHash string) bool {
+	// 1. Check local state cache
+	localState, exists := h.stateMgr.Get(hnc.Name)
+	if !exists || !localState.IsReady(targetHash, h.stateMgr.TTL()) {
+		return false
+	}
+
+	// 2. Check remote CRD status
+	if hnc == nil || hnc.Status.NodeStatus == nil {
+		return false
+	}
+
+	nodeStatus, exists := hnc.Status.NodeStatus[h.nodeName]
+	if !exists {
+		return false
+	}
+
+	// 3. Verify conditions array contains type Ready with status "True"
+	for _, cond := range nodeStatus.Conditions {
+		if cond.Type == networkv1.Ready && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/controller/agent/hostnetworkconfig/controller.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller.go
@@ -30,6 +30,13 @@ const (
 	IPModeStatic   = "static"
 )
 
+// Standard Domain Sentinel Errors
+var (
+	ErrL2NotReady           = errors.New("l2 interface or bridge not ready")
+	ErrL3NotReady           = errors.New("l3 address or dhcp allocation failed")
+	ErrConfigurationInvalid = errors.New("invalid host network spec")
+)
+
 type Handler struct {
 	nodeName          string
 	nodeClient        ctlcorev1.NodeClient
@@ -138,26 +145,27 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 	var addr string
 	var bridgelink *iface.Link
 
+	// --- L2 Setup Phase ---
 	v, err := vlan.GetVlan(hnc.Spec.ClusterNetwork)
 	if err != nil {
 		// hand over to framework to retry
 		logrus.Infof("cluster network %s is not set on this node, something might be wrong", hnc.Spec.ClusterNetwork)
 		//stop and delete all lease manaagers assosciated with the cluster network (if uplink removed due to vlanconfig changes/deletion)
 		// h.stopLeaseManager(utils.GetClusterNetworkVlanDevice(hnc.Spec.ClusterNetwork, hnc.Spec.VlanID))
-		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL2NotReady)
 	}
 
 	bridgelink, err = v.GetBridgelink()
 	if err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL2NotReady)
 	}
 
 	if err = bridgelink.AddBridgeVlanSelf(hnc.Spec.VlanID); err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL2NotReady)
 	}
 
 	if err = bridgelink.CreateVlanSubInterface(hnc.Spec.VlanID); err != nil {
-		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL2NotReady)
 	}
 
 	// reconcile cluster network to add vid to the uplink(cluster-bo)
@@ -165,10 +173,11 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 		return nil, fmt.Errorf("wake up cluster network %s failed, error: %w", hnc.Spec.ClusterNetwork, err)
 	}
 
+	// --- L3 Setup Phase ---
 	switch hnc.Spec.Mode {
 	case IPModeDHCP:
 		if err = h.startLeaseManager(bridgelink, hnc.Spec.VlanID); err != nil {
-			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
+			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL3NotReady)
 		}
 
 	case IPModeStatic:
@@ -176,19 +185,19 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 		h.stopLeaseManager(utils.GetClusterNetworkBrVlanDevice(bridgelink.Attrs().Name, hnc.Spec.VlanID))
 
 		if addr, err = findMatchingIPfromNode(h.nodeName, hnc.Spec.HostIPs); err != nil {
-			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
+			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL3NotReady)
 		}
 
 		if err := bridgelink.SetIPAddress(addr, hnc.Spec.VlanID); err != nil {
-			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
+			return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrL3NotReady)
 		}
 	default:
 		err = fmt.Errorf("unsupported ip assignment mode %s for host network config %s", hnc.Spec.Mode, hnc.Name)
-		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err)
+		return hnc, h.updateHostNetworkReadyStatus(hnc, targetHash, err, ErrConfigurationInvalid)
 	}
 
 	//success case, update host network config status to ready
-	if updateErr := h.updateHostNetworkReadyStatus(hnc, targetHash, nil); updateErr != nil {
+	if updateErr := h.updateHostNetworkReadyStatus(hnc, targetHash, nil, nil); updateErr != nil {
 		return hnc, updateErr
 	}
 
@@ -201,16 +210,20 @@ func (h *Handler) OnChange(_ string, hnc *networkv1.HostNetworkConfig) (*network
 	return hnc, nil
 }
 
-func (h *Handler) updateHostNetworkReadyStatus(hnc *networkv1.HostNetworkConfig, targetHash string, l3setupErr error) error {
-	if statusUpdateErr := h.setHostNetworkStatus(hnc, l3setupErr); statusUpdateErr != nil {
+// updateHostNetworkReadyStatus handles local cache state transitions and applies API status updates.
+// 'l3setupErr' carries the detailed contextual error returned to the controller framework for logging and retry handling.
+// 'categoryErr' specifies the high-level sentinel error (ErrL2NotReady, ErrL3NotReady, ErrConfigurationInvalid).
+func (h *Handler) updateHostNetworkReadyStatus(hnc *networkv1.HostNetworkConfig, targetHash string, l3setupErr error, categoryErr error) error {
+	if statusUpdateErr := h.setHostNetworkStatus(hnc, l3setupErr, categoryErr); statusUpdateErr != nil {
 		// Mark cache as Unknown if status update fails
 		h.stateMgr.CreateOrUpdate(hnc.Name, NewLocalHostNetworkConfigState(targetHash, StateUnknown))
-		return fmt.Errorf("set host network %s ready (%v) failed, error: %w configErr: %v", hnc.Name, l3setupErr == nil, statusUpdateErr, l3setupErr)
+		return fmt.Errorf("set host network %s ready (%v) failed [%w], error: %w configErr: %w", hnc.Name, l3setupErr == nil, categoryErr, statusUpdateErr, l3setupErr)
 	}
 
 	if l3setupErr != nil {
 		h.stateMgr.CreateOrUpdate(hnc.Name, NewLocalHostNetworkConfigState(targetHash, StateUnknown))
-		return fmt.Errorf("setup host network config %s failed, error: %w", hnc.Name, l3setupErr)
+		// Include categoryErr alongside l3setupErr for immediate visibility in controller logs
+		return fmt.Errorf("setup host network config %s failed [%w]: configErr: %w", hnc.Name, categoryErr, l3setupErr)
 	}
 
 	// per node status is ready
@@ -335,12 +348,18 @@ func (h *Handler) removeHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfi
 	return nil
 }
 
-func (h *Handler) setHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfig, ready bool, setupErr error) error {
+// setHostNetworkPerNodeStatus updates the node status conditions for the HostNetworkConfig.
+// We use high-level category errors (sentinel errors like ErrL2NotReady or ErrL3NotReady)
+// rather than raw low-level syscall or netlink errors. CRDs are control-plane state signals,
+// not log aggregators; operators checking a degraded CRD status get a clear high-level
+// reason, while granular debugging details remain in the controller pod logs. This design
+// also prevents etcd write inflation and watch churn from transient, dynamic error text.
+func (h *Handler) setHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfig, ready bool, setupErr error, categoryErr error) error {
 	readyStatus := "True"
 	message := ""
 	if !ready {
 		readyStatus = "False"
-		message = fmt.Sprintf("setup l3 connectivity failed: %v", setupErr)
+		message = fmt.Sprintf("setup l3 connectivity failed: %v", categoryErr)
 	}
 
 	patchPayload := map[string]interface{}{
@@ -380,12 +399,12 @@ func (h *Handler) setHostNetworkPerNodeStatus(hnc *networkv1.HostNetworkConfig, 
 	return nil
 }
 
-func (h *Handler) setHostNetworkStatus(hnc *networkv1.HostNetworkConfig, setupErr error) error {
+func (h *Handler) setHostNetworkStatus(hnc *networkv1.HostNetworkConfig, setupErr error, categoryErr error) error {
 	if setupErr != nil {
-		return h.setHostNetworkPerNodeStatus(hnc, false, setupErr)
+		return h.setHostNetworkPerNodeStatus(hnc, false, setupErr, categoryErr)
 	}
 
-	return h.setHostNetworkPerNodeStatus(hnc, true, nil)
+	return h.setHostNetworkPerNodeStatus(hnc, true, nil, categoryErr)
 }
 
 func (h *Handler) stopLeaseManager(vlanIntfName string) {

--- a/pkg/controller/agent/hostnetworkconfig/controller_test.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller_test.go
@@ -16,15 +16,31 @@ func TestIsAlreadyRemoved(t *testing.T) {
 	validHash := "abc123hash"
 
 	t.Run("empty hash returns false", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
 		if h.isAlreadyRemoved(&networkv1.HostNetworkConfig{}, "") {
 			t.Error("expected false for empty targetHash, got true")
 		}
 	})
 
+	t.Run("state manager disabled returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, true)
+		// Attempting to populate disabled state manager (should be a no-op)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status:     networkv1.HostNetworkConfigStatus{NodeStatus: nil},
+		}
+
+		if h.isAlreadyRemoved(hnc, validHash) {
+			t.Error("expected false when state manager is disabled, got true")
+		}
+	})
+
 	t.Run("state cache missing or not removed returns false", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -37,8 +53,28 @@ func TestIsAlreadyRemoved(t *testing.T) {
 		}
 	})
 
+	t.Run("expired cached state returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
+		expiredState := LocalHostNetworkConfigState{
+			ConfigHash:    validHash,
+			Status:        StateRemoved,
+			LastValidated: time.Now().Add(-10 * time.Minute), // Exceeds 5m TTL
+		}
+		stateMgr.CreateOrUpdate(configName, expiredState)
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status:     networkv1.HostNetworkConfigStatus{NodeStatus: nil},
+		}
+
+		if h.isAlreadyRemoved(hnc, validHash) {
+			t.Error("expected false when cached StateRemoved is expired, got true")
+		}
+	})
+
 	t.Run("cache marked removed and status nil returns true", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -53,7 +89,7 @@ func TestIsAlreadyRemoved(t *testing.T) {
 	})
 
 	t.Run("cache marked removed but node status still present on CRD returns false", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -72,7 +108,7 @@ func TestIsAlreadyRemoved(t *testing.T) {
 	})
 
 	t.Run("cache marked removed and node status cleared returns true", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -97,15 +133,38 @@ func TestIsAlreadyReady(t *testing.T) {
 	validHash := "abc123hash"
 
 	t.Run("empty hash returns false", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
 		if h.isAlreadyReady(&networkv1.HostNetworkConfig{}, "") {
 			t.Error("expected false for empty targetHash, got true")
 		}
 	})
 
+	t.Run("state manager disabled returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, true)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status: networkv1.HostNetworkConfigStatus{
+				NodeStatus: map[string]networkv1.HostNetworkConfigNodeStatus{
+					nodeName: {
+						Conditions: []networkv1.Condition{
+							{Type: networkv1.Ready, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+		}
+
+		if h.isAlreadyReady(hnc, validHash) {
+			t.Error("expected false when state manager is disabled, got true")
+		}
+	})
+
 	t.Run("state cache missing or not ready returns false", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -118,8 +177,36 @@ func TestIsAlreadyReady(t *testing.T) {
 		}
 	})
 
+	t.Run("expired cached state returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
+		expiredState := LocalHostNetworkConfigState{
+			ConfigHash:    validHash,
+			Status:        StateReady,
+			LastValidated: time.Now().Add(-10 * time.Minute), // Exceeds 5m TTL
+		}
+		stateMgr.CreateOrUpdate(configName, expiredState)
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status: networkv1.HostNetworkConfigStatus{
+				NodeStatus: map[string]networkv1.HostNetworkConfigNodeStatus{
+					nodeName: {
+						Conditions: []networkv1.Condition{
+							{Type: networkv1.Ready, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+		}
+
+		if h.isAlreadyReady(hnc, validHash) {
+			t.Error("expected false when cached StateReady is expired, got true")
+		}
+	})
+
 	t.Run("cache ready but CRD status nil returns false", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -134,7 +221,7 @@ func TestIsAlreadyReady(t *testing.T) {
 	})
 
 	t.Run("cache ready but node entry missing in status returns false", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -153,7 +240,7 @@ func TestIsAlreadyReady(t *testing.T) {
 	})
 
 	t.Run("cache ready but Ready condition is False returns false", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -178,8 +265,34 @@ func TestIsAlreadyReady(t *testing.T) {
 		}
 	})
 
+	t.Run("cache ready but Ready condition missing in conditions list returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status: networkv1.HostNetworkConfigStatus{
+				NodeStatus: map[string]networkv1.HostNetworkConfigNodeStatus{
+					nodeName: {
+						Conditions: []networkv1.Condition{
+							{
+								Type:   "InProgress",
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if h.isAlreadyReady(hnc, validHash) {
+			t.Error("expected false when Ready condition type is missing, got true")
+		}
+	})
+
 	t.Run("cache ready and Ready condition is True returns true", func(t *testing.T) {
-		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
 		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
 
 		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
@@ -209,37 +322,43 @@ func TestOnRemove_DeletesCachedState(t *testing.T) {
 	configName := "hnc-test"
 	targetHash := "abc123hash"
 
-	// 1. Initialize state manager and prime it with a cached state
-	stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
-	stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(targetHash, StateReady))
+	t.Run("Evicts existing cached entry upon deletion", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, false)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(targetHash, StateReady))
 
-	// Verify initial state exists in cache
-	if _, exists := stateMgr.Get(configName); !exists {
-		t.Fatalf("expected state for %s to exist before remove, but it was missing", configName)
-	}
+		if _, exists := stateMgr.Get(configName); !exists {
+			t.Fatalf("expected state for %s to exist before remove, but it was missing", configName)
+		}
 
-	hnc := &networkv1.HostNetworkConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: configName,
-		},
-		Spec: networkv1.HostNetworkConfigSpec{
-			ClusterNetwork: "cn-test",
-			VlanID:         100,
-		},
-	}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+		}
 
-	h := &Handler{
-		nodeName: "node-1",
-		stateMgr: stateMgr,
-	}
+		h := &Handler{
+			nodeName: "node-1",
+			stateMgr: stateMgr,
+		}
 
-	// 2. Simulate OnRemove cache eviction step directly
-	// Note: Skipping full h.OnRemove("", hnc) call here to avoid nil pointer panics
-	// or netlink link lookups (e.g., vlan.GetVlan) in non-Linux or un-mocked unit test environments.
-	h.stateMgr.Delete(hnc.Name)
+		// Simulate OnRemove cache eviction step directly
+		h.stateMgr.Delete(hnc.Name)
 
-	// 3. Verify state is deleted and cannot be retrieved
-	if state, exists := stateMgr.Get(configName); exists {
-		t.Errorf("expected state for %s to be deleted, but found state: %+v", configName, state)
-	}
+		if state, exists := stateMgr.Get(configName); exists {
+			t.Errorf("expected state for %s to be deleted, but found state: %+v", configName, state)
+		}
+	})
+
+	t.Run("Delete operates safely when state manager is disabled", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5*time.Minute, true)
+		h := &Handler{
+			nodeName: "node-1",
+			stateMgr: stateMgr,
+		}
+
+		// Delete should perform a clean no-op without panics
+		h.stateMgr.Delete(configName)
+
+		if _, exists := stateMgr.Get(configName); exists {
+			t.Errorf("expected Get to return exists=false when disabled")
+		}
+	})
 }

--- a/pkg/controller/agent/hostnetworkconfig/controller_test.go
+++ b/pkg/controller/agent/hostnetworkconfig/controller_test.go
@@ -1,0 +1,245 @@
+package hostnetworkconfig
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	networkv1 "github.com/harvester/harvester-network-controller/pkg/apis/network.harvesterhci.io/v1beta1"
+)
+
+func TestIsAlreadyRemoved(t *testing.T) {
+	nodeName := "node-1"
+	configName := "hnc-test"
+	validHash := "abc123hash"
+
+	t.Run("empty hash returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		if h.isAlreadyRemoved(&networkv1.HostNetworkConfig{}, "") {
+			t.Error("expected false for empty targetHash, got true")
+		}
+	})
+
+	t.Run("state cache missing or not removed returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+		}
+
+		if h.isAlreadyRemoved(hnc, validHash) {
+			t.Error("expected false when cache is not removed, got true")
+		}
+	})
+
+	t.Run("cache marked removed and status nil returns true", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status:     networkv1.HostNetworkConfigStatus{NodeStatus: nil},
+		}
+
+		if !h.isAlreadyRemoved(hnc, validHash) {
+			t.Error("expected true when cache is removed and status is nil, got false")
+		}
+	})
+
+	t.Run("cache marked removed but node status still present on CRD returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status: networkv1.HostNetworkConfigStatus{
+				NodeStatus: map[string]networkv1.HostNetworkConfigNodeStatus{
+					nodeName: {},
+				},
+			},
+		}
+
+		if h.isAlreadyRemoved(hnc, validHash) {
+			t.Error("expected false when nodeStatus still contains this node, got true")
+		}
+	})
+
+	t.Run("cache marked removed and node status cleared returns true", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status: networkv1.HostNetworkConfigStatus{
+				NodeStatus: map[string]networkv1.HostNetworkConfigNodeStatus{
+					"other-node": {},
+				},
+			},
+		}
+
+		if !h.isAlreadyRemoved(hnc, validHash) {
+			t.Error("expected true when nodeStatus does not contain this node, got false")
+		}
+	})
+}
+
+func TestIsAlreadyReady(t *testing.T) {
+	nodeName := "node-1"
+	configName := "hnc-test"
+	validHash := "abc123hash"
+
+	t.Run("empty hash returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		if h.isAlreadyReady(&networkv1.HostNetworkConfig{}, "") {
+			t.Error("expected false for empty targetHash, got true")
+		}
+	})
+
+	t.Run("state cache missing or not ready returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateRemoved))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+		}
+
+		if h.isAlreadyReady(hnc, validHash) {
+			t.Error("expected false when cache state is not ready, got true")
+		}
+	})
+
+	t.Run("cache ready but CRD status nil returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status:     networkv1.HostNetworkConfigStatus{NodeStatus: nil},
+		}
+
+		if h.isAlreadyReady(hnc, validHash) {
+			t.Error("expected false when CRD NodeStatus is nil, got true")
+		}
+	})
+
+	t.Run("cache ready but node entry missing in status returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status: networkv1.HostNetworkConfigStatus{
+				NodeStatus: map[string]networkv1.HostNetworkConfigNodeStatus{
+					"other-node": {},
+				},
+			},
+		}
+
+		if h.isAlreadyReady(hnc, validHash) {
+			t.Error("expected false when node entry is missing in NodeStatus, got true")
+		}
+	})
+
+	t.Run("cache ready but Ready condition is False returns false", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status: networkv1.HostNetworkConfigStatus{
+				NodeStatus: map[string]networkv1.HostNetworkConfigNodeStatus{
+					nodeName: {
+						Conditions: []networkv1.Condition{
+							{
+								Type:   networkv1.Ready,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if h.isAlreadyReady(hnc, validHash) {
+			t.Error("expected false when Ready condition is False, got true")
+		}
+	})
+
+	t.Run("cache ready and Ready condition is True returns true", func(t *testing.T) {
+		stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+		stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(validHash, StateReady))
+
+		h := &Handler{nodeName: nodeName, stateMgr: stateMgr}
+		hnc := &networkv1.HostNetworkConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: configName},
+			Status: networkv1.HostNetworkConfigStatus{
+				NodeStatus: map[string]networkv1.HostNetworkConfigNodeStatus{
+					nodeName: {
+						Conditions: []networkv1.Condition{
+							{
+								Type:   networkv1.Ready,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if !h.isAlreadyReady(hnc, validHash) {
+			t.Error("expected true when cache is ready and condition is True, got false")
+		}
+	})
+}
+
+func TestOnRemove_DeletesCachedState(t *testing.T) {
+	configName := "hnc-test"
+	targetHash := "abc123hash"
+
+	// 1. Initialize state manager and prime it with a cached state
+	stateMgr := NewLocalHostNetworkConfigStateManager(5 * time.Minute)
+	stateMgr.CreateOrUpdate(configName, NewLocalHostNetworkConfigState(targetHash, StateReady))
+
+	// Verify initial state exists in cache
+	if _, exists := stateMgr.Get(configName); !exists {
+		t.Fatalf("expected state for %s to exist before remove, but it was missing", configName)
+	}
+
+	hnc := &networkv1.HostNetworkConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: configName,
+		},
+		Spec: networkv1.HostNetworkConfigSpec{
+			ClusterNetwork: "cn-test",
+			VlanID:         100,
+		},
+	}
+
+	h := &Handler{
+		nodeName: "node-1",
+		stateMgr: stateMgr,
+	}
+
+	// 2. Simulate OnRemove cache eviction step directly
+	// Note: Skipping full h.OnRemove("", hnc) call here to avoid nil pointer panics
+	// or netlink link lookups (e.g., vlan.GetVlan) in non-Linux or un-mocked unit test environments.
+	h.stateMgr.Delete(hnc.Name)
+
+	// 3. Verify state is deleted and cannot be retrieved
+	if state, exists := stateMgr.Get(configName); exists {
+		t.Errorf("expected state for %s to be deleted, but found state: %+v", configName, state)
+	}
+}

--- a/pkg/controller/agent/hostnetworkconfig/localstatus.go
+++ b/pkg/controller/agent/hostnetworkconfig/localstatus.go
@@ -1,7 +1,9 @@
 package hostnetworkconfig
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -12,11 +14,9 @@ import (
 type ConfigState string
 
 const (
-	StateUnknown  ConfigState = ""         // Default zero-value (uninitialized or newly created)
-	StateSetting  ConfigState = "Setting"  // Setup in progress on the node
-	StateReady    ConfigState = "Ready"    // The node is involved in current HostNetworkConfig and setup is ready
-	StateRemoving ConfigState = "Removing" // Cleanup/teardown in progress on the node
-	StateRemoved  ConfigState = "Removed"  // The node is not involved in current HostNetworkConfig and cleanup is done
+	StateUnknown ConfigState = ""        // Default zero-value (uninitialized or newly created)
+	StateReady   ConfigState = "Ready"   // The node is involved in current HostNetworkConfig and setup is ready
+	StateRemoved ConfigState = "Removed" // The node is not involved in current HostNetworkConfig and cleanup is done
 )
 
 func (c ConfigState) String() string {
@@ -32,7 +32,7 @@ func (c ConfigState) String() string {
 // operational work or quickly exit early (fast exit) to minimize unnecessary processing overhead.
 type LocalHostNetworkConfigState struct {
 	ConfigHash    string      // SHA-256 of the relevant Spec configuration
-	Status        ConfigState // State: Initial, Setting, Ready, Cleaned
+	Status        ConfigState // State: Unknown(initial), Ready, Removed
 	LastValidated time.Time   // Timestamp when system status was last verified
 }
 
@@ -76,6 +76,12 @@ func (s LocalHostNetworkConfigState) IsRemoved(targetHash string, ttl time.Durat
 type LocalHostNetworkConfigStateManager struct {
 	mu sync.RWMutex
 
+	// disabled is set once during initialization and never modified.
+	// Originates from EnvLocalHostNetworkConfigStatusDisable env var.
+	// Treated as strictly immutable during the process lifetime and is deliberately
+	// not protected by the mutex for lock-free read performance.
+	disabled bool
+
 	// ttl is set once during initialization and never modified.
 	// The value originates from an environment variable passed to the pod runtime during initialization
 	// and passed into NewLocalHostNetworkConfigStateManager.
@@ -89,10 +95,11 @@ type LocalHostNetworkConfigStateManager struct {
 
 // NewLocalHostNetworkConfigStateManager creates a manager with a unified TTL for all node states.
 // Set ttl to 0 for no expiration.
-func NewLocalHostNetworkConfigStateManager(ttl time.Duration) *LocalHostNetworkConfigStateManager {
+func NewLocalHostNetworkConfigStateManager(ttl time.Duration, disabled bool) *LocalHostNetworkConfigStateManager {
 	return &LocalHostNetworkConfigStateManager{
-		ttl:   ttl,
-		lhncs: make(map[string]LocalHostNetworkConfigState),
+		disabled: disabled,
+		ttl:      ttl,
+		lhncs:    make(map[string]LocalHostNetworkConfigState),
 	}
 }
 
@@ -101,8 +108,16 @@ func (m *LocalHostNetworkConfigStateManager) TTL() time.Duration {
 	return m.ttl
 }
 
+// Disabled returns the configured disabled for the manager without mutex protection.
+func (m *LocalHostNetworkConfigStateManager) Disabled() bool {
+	return m.disabled
+}
+
 // Get returns a copy of the state for a given node.
 func (m *LocalHostNetworkConfigStateManager) Get(nodeName string) (LocalHostNetworkConfigState, bool) {
+	if m.disabled {
+		return LocalHostNetworkConfigState{}, false
+	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -113,6 +128,9 @@ func (m *LocalHostNetworkConfigStateManager) Get(nodeName string) (LocalHostNetw
 // CreateOrUpdate accepts the node name and a LocalHostNetworkConfigState object.
 // Returns true if a new entry was created, or false if an existing entry was updated.
 func (m *LocalHostNetworkConfigStateManager) CreateOrUpdate(hnc string, state LocalHostNetworkConfigState) bool {
+	if m.disabled {
+		return false
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -123,14 +141,30 @@ func (m *LocalHostNetworkConfigStateManager) CreateOrUpdate(hnc string, state Lo
 
 // Delete removes a node state entry.
 func (m *LocalHostNetworkConfigStateManager) Delete(hnc string) {
+	if m.disabled {
+		return
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	delete(m.lhncs, hnc)
 }
 
-// getTTLFromEnvOrDefault returns the parsed time.Duration from the LOCAL_STATUS_TTL env var.
-// If the variable is unset, empty, or fails to parse, it falls back to DefaultLocalStatusTTL.
+// String implements the fmt.Stringer interface for debug logging.
+func (m *LocalHostNetworkConfigStateManager) String() string {
+	if m.disabled {
+		return "LocalHostNetworkConfigStateManager{disabled: true}"
+	}
+
+	m.mu.RLock()
+	count := len(m.lhncs)
+	m.mu.RUnlock()
+
+	return fmt.Sprintf("LocalHostNetworkConfigStateManager{disabled: false, ttl: %s, count: %d}", m.ttl, count)
+}
+
+// getTTLFromEnvOrDefault returns the parsed time.Duration from the LOCAL_HOST_NETWORK_CONFIG_STATUS_TTL env var.
+// If the variable is unset, empty, fails to parse, or is negative, it falls back to DefaultLocalHostNetworkConfigStatusTTL.
 func getTTLFromEnvOrDefault() time.Duration {
 	envVal := os.Getenv(utils.EnvLocalHostNetworkConfigStatusTTL)
 	if envVal == "" {
@@ -143,5 +177,26 @@ func getTTLFromEnvOrDefault() time.Duration {
 		return utils.DefaultLocalHostNetworkConfigStatusTTL
 	}
 
+	if ttl < 0 {
+		logrus.Warnf("%s value %v is negative, defaulting to %v", utils.EnvLocalHostNetworkConfigStatusTTL, ttl, utils.DefaultLocalHostNetworkConfigStatusTTL)
+		return utils.DefaultLocalHostNetworkConfigStatusTTL
+	}
+
 	return ttl
+}
+
+// getDisableFromEnvOrDefault returns true if the state manager is explicitly disabled via env var.
+func getDisableFromEnvOrDefault() bool {
+	envVal := os.Getenv(utils.EnvLocalHostNetworkConfigStatusDisable)
+	if envVal == "" {
+		return false
+	}
+
+	disabled, err := strconv.ParseBool(envVal)
+	if err != nil {
+		logrus.Warnf("Failed to parse %s value %q as bool, defaulting to false: %v", utils.EnvLocalHostNetworkConfigStatusDisable, envVal, err)
+		return false
+	}
+
+	return disabled
 }

--- a/pkg/controller/agent/hostnetworkconfig/localstatus.go
+++ b/pkg/controller/agent/hostnetworkconfig/localstatus.go
@@ -47,6 +47,10 @@ func NewLocalHostNetworkConfigState(configHash string, status ConfigState) Local
 
 // isValidState encapsulates the common validation logic across different target states.
 func (s LocalHostNetworkConfigState) isValidState(expectedStatus ConfigState, targetHash string, ttl time.Duration) bool {
+	// empty targetHash is always invalid
+	if targetHash == "" {
+		return false
+	}
 	if s.Status != expectedStatus {
 		return false
 	}
@@ -80,7 +84,7 @@ type LocalHostNetworkConfigStateManager struct {
 	// not protected by the mutex for lock-free read performance.
 	ttl time.Duration
 
-	nodes map[string]LocalHostNetworkConfigState
+	lhncs map[string]LocalHostNetworkConfigState
 }
 
 // NewLocalHostNetworkConfigStateManager creates a manager with a unified TTL for all node states.
@@ -88,7 +92,7 @@ type LocalHostNetworkConfigStateManager struct {
 func NewLocalHostNetworkConfigStateManager(ttl time.Duration) *LocalHostNetworkConfigStateManager {
 	return &LocalHostNetworkConfigStateManager{
 		ttl:   ttl,
-		nodes: make(map[string]LocalHostNetworkConfigState),
+		lhncs: make(map[string]LocalHostNetworkConfigState),
 	}
 }
 
@@ -102,27 +106,27 @@ func (m *LocalHostNetworkConfigStateManager) Get(nodeName string) (LocalHostNetw
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	state, exists := m.nodes[nodeName]
+	state, exists := m.lhncs[nodeName]
 	return state, exists
 }
 
 // CreateOrUpdate accepts the node name and a LocalHostNetworkConfigState object.
 // Returns true if a new entry was created, or false if an existing entry was updated.
-func (m *LocalHostNetworkConfigStateManager) CreateOrUpdate(nodeName string, state LocalHostNetworkConfigState) bool {
+func (m *LocalHostNetworkConfigStateManager) CreateOrUpdate(hnc string, state LocalHostNetworkConfigState) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	_, exists := m.nodes[nodeName]
-	m.nodes[nodeName] = state
+	_, exists := m.lhncs[hnc]
+	m.lhncs[hnc] = state
 	return !exists
 }
 
 // Delete removes a node state entry.
-func (m *LocalHostNetworkConfigStateManager) Delete(nodeName string) {
+func (m *LocalHostNetworkConfigStateManager) Delete(hnc string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.nodes, nodeName)
+	delete(m.lhncs, hnc)
 }
 
 // getTTLFromEnvOrDefault returns the parsed time.Duration from the LOCAL_STATUS_TTL env var.

--- a/pkg/controller/agent/hostnetworkconfig/localstatus.go
+++ b/pkg/controller/agent/hostnetworkconfig/localstatus.go
@@ -1,0 +1,143 @@
+package hostnetworkconfig
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"github.com/harvester/harvester-network-controller/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+type ConfigState string
+
+const (
+	StateUnknown  ConfigState = ""         // Default zero-value (uninitialized or newly created)
+	StateSetting  ConfigState = "Setting"  // Setup in progress on the node
+	StateReady    ConfigState = "Ready"    // The node is involved in current HostNetworkConfig and setup is ready
+	StateRemoving ConfigState = "Removing" // Cleanup/teardown in progress on the node
+	StateRemoved  ConfigState = "Removed"  // The node is not involved in current HostNetworkConfig and cleanup is done
+)
+
+func (c ConfigState) String() string {
+	if c == StateUnknown {
+		return "Unknown"
+	}
+	return string(c)
+}
+
+// As HostNetworkConfig is a cluster-wide object that records the status of each node
+// within a status map, any single node status change triggers a cluster-wide re-sync across nodes.
+// This local cache object enables the agent controller on each node to determine whether it must perform
+// operational work or quickly exit early (fast exit) to minimize unnecessary processing overhead.
+type LocalHostNetworkConfigState struct {
+	ConfigHash    string      // SHA-256 of the relevant Spec configuration
+	Status        ConfigState // State: Initial, Setting, Ready, Cleaned
+	LastValidated time.Time   // Timestamp when system status was last verified
+}
+
+// NewLocalHostNetworkConfigState creates a new state instance with LastValidated set to time.Now().
+func NewLocalHostNetworkConfigState(configHash string, status ConfigState) LocalHostNetworkConfigState {
+	return LocalHostNetworkConfigState{
+		ConfigHash:    configHash,
+		Status:        status,
+		LastValidated: time.Now(),
+	}
+}
+
+// isValidState encapsulates the common validation logic across different target states.
+func (s LocalHostNetworkConfigState) isValidState(expectedStatus ConfigState, targetHash string, ttl time.Duration) bool {
+	if s.Status != expectedStatus {
+		return false
+	}
+	if s.ConfigHash != targetHash {
+		return false
+	}
+	if ttl == 0 {
+		return true
+	}
+	return time.Now().Before(s.LastValidated.Add(ttl))
+}
+
+// IsReady checks if the node configuration is ready, matches targetHash, and has not expired according to ttl.
+func (s LocalHostNetworkConfigState) IsReady(targetHash string, ttl time.Duration) bool {
+	return s.isValidState(StateReady, targetHash, ttl)
+}
+
+// IsRemoved checks if the node cleanup is completed, matches targetHash, and has not expired according to ttl.
+func (s LocalHostNetworkConfigState) IsRemoved(targetHash string, ttl time.Duration) bool {
+	return s.isValidState(StateRemoved, targetHash, ttl)
+}
+
+type LocalHostNetworkConfigStateManager struct {
+	mu sync.RWMutex
+
+	// ttl is set once during initialization and never modified.
+	// The value originates from an environment variable passed to the pod runtime during initialization
+	// and passed into NewLocalHostNetworkConfigStateManager.
+	// If the environment variable changes, Kubernetes restarts/replaces the pod, creating a fresh manager.
+	// Therefore, ttl is treated as strictly immutable during the process lifetime and is deliberately
+	// not protected by the mutex for lock-free read performance.
+	ttl time.Duration
+
+	nodes map[string]LocalHostNetworkConfigState
+}
+
+// NewLocalHostNetworkConfigStateManager creates a manager with a unified TTL for all node states.
+// Set ttl to 0 for no expiration.
+func NewLocalHostNetworkConfigStateManager(ttl time.Duration) *LocalHostNetworkConfigStateManager {
+	return &LocalHostNetworkConfigStateManager{
+		ttl:   ttl,
+		nodes: make(map[string]LocalHostNetworkConfigState),
+	}
+}
+
+// TTL returns the configured TTL for the manager without mutex protection.
+func (m *LocalHostNetworkConfigStateManager) TTL() time.Duration {
+	return m.ttl
+}
+
+// Get returns a copy of the state for a given node.
+func (m *LocalHostNetworkConfigStateManager) Get(nodeName string) (LocalHostNetworkConfigState, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state, exists := m.nodes[nodeName]
+	return state, exists
+}
+
+// CreateOrUpdate accepts the node name and a LocalHostNetworkConfigState object.
+// Returns true if a new entry was created, or false if an existing entry was updated.
+func (m *LocalHostNetworkConfigStateManager) CreateOrUpdate(nodeName string, state LocalHostNetworkConfigState) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, exists := m.nodes[nodeName]
+	m.nodes[nodeName] = state
+	return !exists
+}
+
+// Delete removes a node state entry.
+func (m *LocalHostNetworkConfigStateManager) Delete(nodeName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.nodes, nodeName)
+}
+
+// getTTLFromEnvOrDefault returns the parsed time.Duration from the LOCAL_STATUS_TTL env var.
+// If the variable is unset, empty, or fails to parse, it falls back to DefaultLocalStatusTTL.
+func getTTLFromEnvOrDefault() time.Duration {
+	envVal := os.Getenv(utils.EnvLocalHostNetworkConfigStatusTTL)
+	if envVal == "" {
+		return utils.DefaultLocalHostNetworkConfigStatusTTL
+	}
+
+	ttl, err := time.ParseDuration(envVal)
+	if err != nil {
+		logrus.Warnf("Failed to parse %s value %q, defaulting to %v: %v", utils.EnvLocalHostNetworkConfigStatusTTL, envVal, utils.DefaultLocalHostNetworkConfigStatusTTL, err)
+		return utils.DefaultLocalHostNetworkConfigStatusTTL
+	}
+
+	return ttl
+}

--- a/pkg/controller/agent/hostnetworkconfig/localstatus.go
+++ b/pkg/controller/agent/hostnetworkconfig/localstatus.go
@@ -115,14 +115,14 @@ func (m *LocalHostNetworkConfigStateManager) Disabled() bool {
 // Get returns a copy of the state for a given HostNetworkConfig name.
 // Returns an empty state and false immediately if the state manager is disabled.
 // The zero-value state guarantees IsReady and IsRemoved return false, allowing callers to check status without explicitly handling the disabled state.
-func (m *LocalHostNetworkConfigStateManager) Get(nodeName string) (LocalHostNetworkConfigState, bool) {
+func (m *LocalHostNetworkConfigStateManager) Get(hnc string) (LocalHostNetworkConfigState, bool) {
 	if m.disabled {
 		return LocalHostNetworkConfigState{}, false
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	state, exists := m.lhncs[nodeName]
+	state, exists := m.lhncs[hnc]
 	return state, exists
 }
 

--- a/pkg/controller/agent/hostnetworkconfig/localstatus.go
+++ b/pkg/controller/agent/hostnetworkconfig/localstatus.go
@@ -47,28 +47,27 @@ func NewLocalHostNetworkConfigState(configHash string, status ConfigState) Local
 
 // isValidState encapsulates the common validation logic across different target states.
 func (s LocalHostNetworkConfigState) isValidState(expectedStatus ConfigState, targetHash string, ttl time.Duration) bool {
-	// empty targetHash is always invalid
-	if targetHash == "" {
+	// Fast-path return for empty/zero-value states (such as when the state manager is disabled or an entry is missing),
+	// empty targetHash inputs, or mismatched hashes.
+	if s.ConfigHash == "" || targetHash == "" || s.ConfigHash != targetHash {
 		return false
 	}
 	if s.Status != expectedStatus {
 		return false
 	}
-	if s.ConfigHash != targetHash {
-		return false
-	}
+	// ttl value 0 means no expiration.
 	if ttl == 0 {
 		return true
 	}
 	return time.Now().Before(s.LastValidated.Add(ttl))
 }
 
-// IsReady checks if the node configuration is ready, matches targetHash, and has not expired according to ttl.
+// IsReady checks if the state is ready.
 func (s LocalHostNetworkConfigState) IsReady(targetHash string, ttl time.Duration) bool {
 	return s.isValidState(StateReady, targetHash, ttl)
 }
 
-// IsRemoved checks if the node cleanup is completed, matches targetHash, and has not expired according to ttl.
+// IsRemoved checks if the cleanup is completed.
 func (s LocalHostNetworkConfigState) IsRemoved(targetHash string, ttl time.Duration) bool {
 	return s.isValidState(StateRemoved, targetHash, ttl)
 }
@@ -113,7 +112,9 @@ func (m *LocalHostNetworkConfigStateManager) Disabled() bool {
 	return m.disabled
 }
 
-// Get returns a copy of the state for a given node.
+// Get returns a copy of the state for a given HostNetworkConfig name.
+// Returns an empty state and false immediately if the state manager is disabled.
+// The zero-value state guarantees IsReady and IsRemoved return false, allowing callers to check status without explicitly handling the disabled state.
 func (m *LocalHostNetworkConfigStateManager) Get(nodeName string) (LocalHostNetworkConfigState, bool) {
 	if m.disabled {
 		return LocalHostNetworkConfigState{}, false
@@ -125,8 +126,9 @@ func (m *LocalHostNetworkConfigStateManager) Get(nodeName string) (LocalHostNetw
 	return state, exists
 }
 
-// CreateOrUpdate accepts the node name and a LocalHostNetworkConfigState object.
+// CreateOrUpdate accepts a HostNetworkConfig name and a LocalHostNetworkConfigState object.
 // Returns true if a new entry was created, or false if an existing entry was updated.
+// Performs a no-op and returns false immediately if the state manager is disabled.
 func (m *LocalHostNetworkConfigStateManager) CreateOrUpdate(hnc string, state LocalHostNetworkConfigState) bool {
 	if m.disabled {
 		return false
@@ -139,7 +141,8 @@ func (m *LocalHostNetworkConfigStateManager) CreateOrUpdate(hnc string, state Lo
 	return !exists
 }
 
-// Delete removes a node state entry.
+// Delete removes a HostNetworkConfig state entry by name.
+// Performs a no-op immediately if the state manager is disabled.
 func (m *LocalHostNetworkConfigStateManager) Delete(hnc string) {
 	if m.disabled {
 		return

--- a/pkg/controller/agent/hostnetworkconfig/localstatus_test.go
+++ b/pkg/controller/agent/hostnetworkconfig/localstatus_test.go
@@ -1,0 +1,222 @@
+package hostnetworkconfig
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLocalHostNetworkConfigState_IsReady(t *testing.T) {
+	targetHash := "hash-12345"
+	wrongHash := "hash-99999"
+
+	tests := []struct {
+		name       string
+		state      LocalHostNetworkConfigState
+		targetHash string
+		ttl        time.Duration
+		want       bool
+	}{
+		{
+			name: "Valid StateReady with non-zero TTL before expiration",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateReady,
+				LastValidated: time.Now().Add(-5 * time.Minute),
+			},
+			targetHash: targetHash,
+			ttl:        10 * time.Minute,
+			want:       true,
+		},
+		{
+			name: "Expired StateReady with non-zero TTL",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateReady,
+				LastValidated: time.Now().Add(-15 * time.Minute),
+			},
+			targetHash: targetHash,
+			ttl:        10 * time.Minute,
+			want:       false,
+		},
+		{
+			name: "StateReady with zero TTL bypasses duration check (old timestamp)",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateReady,
+				LastValidated: time.Now().Add(-24 * time.Hour),
+			},
+			targetHash: targetHash,
+			ttl:        0,
+			want:       true,
+		},
+		{
+			name: "Mismatched ConfigHash",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateReady,
+				LastValidated: time.Now(),
+			},
+			targetHash: wrongHash,
+			ttl:        10 * time.Minute,
+			want:       false,
+		},
+		{
+			name: "Incorrect Status (StateSetting instead of StateReady)",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateSetting,
+				LastValidated: time.Now(),
+			},
+			targetHash: targetHash,
+			ttl:        10 * time.Minute,
+			want:       false,
+		},
+		{
+			name: "Incorrect Status (StateRemoved instead of StateReady)",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateRemoved,
+				LastValidated: time.Now(),
+			},
+			targetHash: targetHash,
+			ttl:        10 * time.Minute,
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.state.IsReady(tt.targetHash, tt.ttl)
+			if got != tt.want {
+				t.Errorf("IsReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalHostNetworkConfigState_IsRemoved(t *testing.T) {
+	targetHash := "hash-12345"
+	wrongHash := "hash-99999"
+
+	tests := []struct {
+		name       string
+		state      LocalHostNetworkConfigState
+		targetHash string
+		ttl        time.Duration
+		want       bool
+	}{
+		{
+			name: "Valid StateRemoved with non-zero TTL before expiration",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateRemoved,
+				LastValidated: time.Now().Add(-2 * time.Minute),
+			},
+			targetHash: targetHash,
+			ttl:        5 * time.Minute,
+			want:       true,
+		},
+		{
+			name: "Expired StateRemoved with non-zero TTL",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateRemoved,
+				LastValidated: time.Now().Add(-10 * time.Minute),
+			},
+			targetHash: targetHash,
+			ttl:        5 * time.Minute,
+			want:       false,
+		},
+		{
+			name: "StateRemoved with zero TTL bypasses duration check (old timestamp)",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateRemoved,
+				LastValidated: time.Now().Add(-48 * time.Hour),
+			},
+			targetHash: targetHash,
+			ttl:        0,
+			want:       true,
+		},
+		{
+			name: "Mismatched ConfigHash",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateRemoved,
+				LastValidated: time.Now(),
+			},
+			targetHash: wrongHash,
+			ttl:        5 * time.Minute,
+			want:       false,
+		},
+		{
+			name: "Incorrect Status (StateRemoving instead of StateRemoved)",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateRemoving,
+				LastValidated: time.Now(),
+			},
+			targetHash: targetHash,
+			ttl:        5 * time.Minute,
+			want:       false,
+		},
+		{
+			name: "Incorrect Status (StateReady instead of StateRemoved)",
+			state: LocalHostNetworkConfigState{
+				ConfigHash:    targetHash,
+				Status:        StateReady,
+				LastValidated: time.Now(),
+			},
+			targetHash: targetHash,
+			ttl:        5 * time.Minute,
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.state.IsRemoved(tt.targetHash, tt.ttl)
+			if got != tt.want {
+				t.Errorf("IsRemoved() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalHostNetworkConfigStateManager_Get_IsReady_Integration(t *testing.T) {
+	nodeName := "node-1"
+	targetHash := "hash-abc"
+	ttl := 10 * time.Minute
+
+	mgr := NewLocalHostNetworkConfigStateManager(ttl)
+
+	// Case 1: Node does not exist
+	if _, exists := mgr.Get(nodeName); exists {
+		t.Fatalf("expected node %s to not exist in manager", nodeName)
+	}
+
+	// Case 2: Store ready state and query via Get()
+	state := NewLocalHostNetworkConfigState(targetHash, StateReady)
+	mgr.CreateOrUpdate(nodeName, state)
+
+	fetchedState, exists := mgr.Get(nodeName)
+	if !exists {
+		t.Fatalf("expected node %s to exist in manager", nodeName)
+	}
+
+	if !fetchedState.IsReady(targetHash, mgr.TTL()) {
+		t.Errorf("expected fetchedState.IsReady() to be true")
+	}
+
+	// Case 3: Update to removed state and verify
+	removedState := NewLocalHostNetworkConfigState(targetHash, StateRemoved)
+	mgr.CreateOrUpdate(nodeName, removedState)
+
+	fetchedState, _ = mgr.Get(nodeName)
+	if fetchedState.IsReady(targetHash, mgr.TTL()) {
+		t.Errorf("expected fetchedState.IsReady() to be false after updating to StateRemoved")
+	}
+	if !fetchedState.IsRemoved(targetHash, mgr.TTL()) {
+		t.Errorf("expected fetchedState.IsRemoved() to be true")
+	}
+}

--- a/pkg/controller/agent/hostnetworkconfig/localstatus_test.go
+++ b/pkg/controller/agent/hostnetworkconfig/localstatus_test.go
@@ -1,8 +1,11 @@
 package hostnetworkconfig
 
 import (
+	"os"
 	"testing"
 	"time"
+
+	"github.com/harvester/harvester-network-controller/pkg/utils"
 )
 
 func TestLocalHostNetworkConfigState_IsReady(t *testing.T) {
@@ -57,17 +60,6 @@ func TestLocalHostNetworkConfigState_IsReady(t *testing.T) {
 				LastValidated: time.Now(),
 			},
 			targetHash: wrongHash,
-			ttl:        10 * time.Minute,
-			want:       false,
-		},
-		{
-			name: "Incorrect Status (StateSetting instead of StateReady)",
-			state: LocalHostNetworkConfigState{
-				ConfigHash:    targetHash,
-				Status:        StateSetting,
-				LastValidated: time.Now(),
-			},
-			targetHash: targetHash,
 			ttl:        10 * time.Minute,
 			want:       false,
 		},
@@ -150,17 +142,6 @@ func TestLocalHostNetworkConfigState_IsRemoved(t *testing.T) {
 			want:       false,
 		},
 		{
-			name: "Incorrect Status (StateRemoving instead of StateRemoved)",
-			state: LocalHostNetworkConfigState{
-				ConfigHash:    targetHash,
-				Status:        StateRemoving,
-				LastValidated: time.Now(),
-			},
-			targetHash: targetHash,
-			ttl:        5 * time.Minute,
-			want:       false,
-		},
-		{
 			name: "Incorrect Status (StateReady instead of StateRemoved)",
 			state: LocalHostNetworkConfigState{
 				ConfigHash:    targetHash,
@@ -188,7 +169,7 @@ func TestLocalHostNetworkConfigStateManager_Get_IsReady_Integration(t *testing.T
 	targetHash := "hash-abc"
 	ttl := 10 * time.Minute
 
-	mgr := NewLocalHostNetworkConfigStateManager(ttl)
+	mgr := NewLocalHostNetworkConfigStateManager(ttl, false)
 
 	// Case 1: Node does not exist
 	if _, exists := mgr.Get(nodeName); exists {
@@ -218,5 +199,183 @@ func TestLocalHostNetworkConfigStateManager_Get_IsReady_Integration(t *testing.T
 	}
 	if !fetchedState.IsRemoved(targetHash, mgr.TTL()) {
 		t.Errorf("expected fetchedState.IsRemoved() to be true")
+	}
+}
+
+func TestLocalHostNetworkConfigStateManager_Disabled(t *testing.T) {
+	nodeName := "node-1"
+	targetHash := "hash-abc"
+	ttl := 10 * time.Minute
+
+	t.Run("Disabled manager blocks writes and returns empty on reads", func(t *testing.T) {
+		mgr := NewLocalHostNetworkConfigStateManager(ttl, true)
+
+		if !mgr.Disabled() {
+			t.Errorf("expected Disabled() to be true")
+		}
+
+		// CreateOrUpdate should perform a no-op and return false
+		state := NewLocalHostNetworkConfigState(targetHash, StateReady)
+		created := mgr.CreateOrUpdate(nodeName, state)
+		if created {
+			t.Errorf("expected CreateOrUpdate() to return false when disabled")
+		}
+
+		// Get should return empty state and exists=false
+		fetchedState, exists := mgr.Get(nodeName)
+		if exists {
+			t.Errorf("expected Get() exists to be false when disabled")
+		}
+
+		// IsReady / IsRemoved helper checks on fetched state should evaluate to false
+		if fetchedState.IsReady(targetHash, mgr.TTL()) {
+			t.Errorf("expected IsReady() to be false on empty state from disabled manager")
+		}
+		if fetchedState.IsRemoved(targetHash, mgr.TTL()) {
+			t.Errorf("expected IsRemoved() to be false on empty state from disabled manager")
+		}
+
+		// Delete should execute safely as a no-op
+		mgr.Delete(nodeName)
+	})
+
+	t.Run("Disabled manager String output", func(t *testing.T) {
+		mgrDisabled := NewLocalHostNetworkConfigStateManager(ttl, true)
+		expectedDisabledStr := "LocalHostNetworkConfigStateManager{disabled: true}"
+		if got := mgrDisabled.String(); got != expectedDisabledStr {
+			t.Errorf("String() = %q, want %q", got, expectedDisabledStr)
+		}
+
+		mgrEnabled := NewLocalHostNetworkConfigStateManager(ttl, false)
+		expectedEnabledStr := "LocalHostNetworkConfigStateManager{disabled: false, ttl: 10m0s, count: 0}"
+		if got := mgrEnabled.String(); got != expectedEnabledStr {
+			t.Errorf("String() = %q, want %q", got, expectedEnabledStr)
+		}
+	})
+}
+
+func Test_getDisableFromEnvOrDefault(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+		setEnv bool
+		want   bool
+	}{
+		{
+			name:   "Env unset defaults to false",
+			setEnv: false,
+			want:   false,
+		},
+		{
+			name:   "Env empty defaults to false",
+			envVal: "",
+			setEnv: true,
+			want:   false,
+		},
+		{
+			name:   "Env set to 'true'",
+			envVal: "true",
+			setEnv: true,
+			want:   true,
+		},
+		{
+			name:   "Env set to '1'",
+			envVal: "1",
+			setEnv: true,
+			want:   true,
+		},
+		{
+			name:   "Env set to 'false'",
+			envVal: "false",
+			setEnv: true,
+			want:   false,
+		},
+		{
+			name:   "Env set to invalid boolean value defaults to false",
+			envVal: "not-a-bool",
+			setEnv: true,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(utils.EnvLocalHostNetworkConfigStatusDisable, tt.envVal)
+			} else {
+				os.Unsetenv(utils.EnvLocalHostNetworkConfigStatusDisable)
+			}
+
+			got := getDisableFromEnvOrDefault()
+			if got != tt.want {
+				t.Errorf("getDisableFromEnvOrDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getTTLFromEnvOrDefault(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+		setEnv bool
+		want   time.Duration
+	}{
+		{
+			name:   "Env unset defaults to DefaultLocalHostNetworkConfigStatusTTL",
+			setEnv: false,
+			want:   utils.DefaultLocalHostNetworkConfigStatusTTL,
+		},
+		{
+			name:   "Env empty defaults to DefaultLocalHostNetworkConfigStatusTTL",
+			envVal: "",
+			setEnv: true,
+			want:   utils.DefaultLocalHostNetworkConfigStatusTTL,
+		},
+		{
+			name:   "Env set to valid duration '10m'",
+			envVal: "10m",
+			setEnv: true,
+			want:   10 * time.Minute,
+		},
+		{
+			name:   "Env set to valid duration '30s'",
+			envVal: "30s",
+			setEnv: true,
+			want:   30 * time.Second,
+		},
+		{
+			name:   "Env set to zero '0s'",
+			envVal: "0s",
+			setEnv: true,
+			want:   0,
+		},
+		{
+			name:   "Env set to invalid duration string defaults to DefaultLocalHostNetworkConfigStatusTTL",
+			envVal: "invalid-duration",
+			setEnv: true,
+			want:   utils.DefaultLocalHostNetworkConfigStatusTTL,
+		},
+		{
+			name:   "Env set to negative duration defaults to DefaultLocalHostNetworkConfigStatusTTL",
+			envVal: "-5m",
+			setEnv: true,
+			want:   utils.DefaultLocalHostNetworkConfigStatusTTL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(utils.EnvLocalHostNetworkConfigStatusTTL, tt.envVal)
+			} else {
+				os.Unsetenv(utils.EnvLocalHostNetworkConfigStatusTTL)
+			}
+
+			got := getTTLFromEnvOrDefault()
+			if got != tt.want {
+				t.Errorf("getTTLFromEnvOrDefault() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -40,14 +40,16 @@ func GetClusterNetworkDevicePrefix(cnName string) string {
 	return fmt.Sprintf("%s%s%s", cnName, BridgeSuffix, VlanSubInterfaceSpliter)
 }
 
-// e.g. cn2-br.2025
-func GetClusterNetworkBrVlanDevice(cnBrName string, vlanId uint16) string {
-	return fmt.Sprintf("%s%s%s", cnBrName, VlanSubInterfaceSpliter, fmt.Sprint(vlanId))
+// GetClusterNetworkBrVlanDevice formats a VLAN sub-interface from a bridge name.
+// Example: "cn2-br", 2025 -> "cn2-br.2025"
+func GetClusterNetworkBrVlanDevice(cnBrName string, vlanID uint16) string {
+	return fmt.Sprintf("%s%s%d", cnBrName, VlanSubInterfaceSpliter, vlanID)
 }
 
-// e.g. cn2-br.2025
-func GetClusterNetworkVlanDevice(cnName string, vlanId uint16) string {
-	return fmt.Sprintf("%s%s", GetClusterNetworkDevicePrefix(cnName), fmt.Sprint(vlanId))
+// GetClusterNetworkVlanDevice formats a VLAN device using the cluster network device prefix.
+// Example: "cn2", 2025 -> "cn2-br.2025"
+func GetClusterNetworkVlanDevice(cnName string, vlanID uint16) string {
+	return fmt.Sprintf("%s%d", GetClusterNetworkDevicePrefix(cnName), vlanID)
 }
 
 func HasClusterNetworkDevicePrefix(link, prefix string) bool {

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -19,4 +19,7 @@ const (
 
 	// EnvLocalHostNetworkConfigStatusTTL defines the environment variable key for configuring state TTL.
 	EnvLocalHostNetworkConfigStatusTTL = "LOCAL_HOST_NETWORK_CONFIG_STATUS_TTL"
+
+	// EnvLocalHostNetworkConfigStatusDisable defines the environment variable key to explicitly disable the local state cache.
+	EnvLocalHostNetworkConfigStatusDisable = "LOCAL_HOST_NETWORK_CONFIG_STATUS_DISABLE"
 )

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -1,5 +1,9 @@
 package utils
 
+import (
+	"time"
+)
+
 const (
 	DefaultMTU       = 1500
 	MaxMTU           = 9000
@@ -9,4 +13,10 @@ const (
 	HarvesterSystemNamespaceName = "harvester-system" // don't import harvester/pkg/util to avoid loop importing, define it directly
 
 	EnvLogLevel = "LOGLEVEL"
+
+	// DefaultLocalHostNetworkConfigStatusTTL is the fallback duration for local state validity.
+	DefaultLocalHostNetworkConfigStatusTTL = 5 * time.Minute
+
+	// EnvLocalHostNetworkConfigStatusTTL defines the environment variable key for configuring state TTL.
+	EnvLocalHostNetworkConfigStatusTTL = "LOCAL_HOST_NETWORK_CONFIG_STATUS_TTL"
 )

--- a/pkg/utils/hostnetworkconfig.go
+++ b/pkg/utils/hostnetworkconfig.go
@@ -10,8 +10,13 @@ import (
 
 // ComputeSpecHash generates a deterministic SHA-256 hex string representation of the given object.
 func ComputeSpecHash(spec interface{}) (string, error) {
-	if spec == nil || (reflect.ValueOf(spec).Kind() == reflect.Pointer && reflect.ValueOf(spec).IsNil()) {
+	if spec == nil {
 		return "", fmt.Errorf("cannot compute hash for nil spec")
+	}
+
+	v := reflect.ValueOf(spec)
+	if v.Kind() == reflect.Pointer && v.IsNil() {
+		return "", fmt.Errorf("cannot compute hash for nil spec after reflect.ValueOf(spec)")
 	}
 
 	data, err := json.Marshal(spec)

--- a/pkg/utils/hostnetworkconfig.go
+++ b/pkg/utils/hostnetworkconfig.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// ComputeSpecHash generates a deterministic SHA-256 hex string representation of the given object.
+func ComputeSpecHash(spec interface{}) (string, error) {
+	if spec == nil || (reflect.ValueOf(spec).Kind() == reflect.Pointer && reflect.ValueOf(spec).IsNil()) {
+		return "", fmt.Errorf("cannot compute hash for nil spec")
+	}
+
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal spec for hashing: %w", err)
+	}
+
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
+}

--- a/pkg/utils/hostnetworkconfig_test.go
+++ b/pkg/utils/hostnetworkconfig_test.go
@@ -1,0 +1,113 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+type DummySpec struct {
+	ClusterNetwork string            `json:"clusterNetwork"`
+	VlanID         int               `json:"vlanId"`
+	NodeSelector   map[string]string `json:"nodeSelector"`
+	HostIPs        []string          `json:"hostIPs"`
+	Underlay       bool              `json:"underlay"`
+}
+
+func TestComputeSpecHash(t *testing.T) {
+	baseSpec := DummySpec{
+		ClusterNetwork: "vlan",
+		VlanID:         100,
+		NodeSelector: map[string]string{
+			"kubernetes.io/hostname":      "node1",
+			"topology.kubernetes.io/zone": "zone-a",
+		},
+		HostIPs:  []string{"192.168.1.10/24"},
+		Underlay: true,
+	}
+
+	t.Run("valid struct returns non-empty hash", func(t *testing.T) {
+		hash, err := ComputeSpecHash(baseSpec)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if len(hash) != 64 {
+			t.Errorf("expected 64-character SHA-256 hex string, got length %d (%s)", len(hash), hash)
+		}
+	})
+
+	t.Run("untyped nil spec returns error", func(t *testing.T) {
+		hash, err := ComputeSpecHash(nil)
+		if err == nil {
+			t.Fatal("expected error for untyped nil spec, got nil")
+		}
+		if hash != "" {
+			t.Errorf("expected empty hash string, got: %s", hash)
+		}
+		if !strings.Contains(err.Error(), "cannot compute hash for nil spec") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("typed nil pointer spec returns error", func(t *testing.T) {
+		var nilSpec *DummySpec
+		hash, err := ComputeSpecHash(nilSpec)
+		if err == nil {
+			t.Fatal("expected error for typed nil pointer spec, got nil")
+		}
+		if hash != "" {
+			t.Errorf("expected empty hash string, got: %s", hash)
+		}
+		if !strings.Contains(err.Error(), "cannot compute hash for nil spec") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("deterministic hash across identical structs", func(t *testing.T) {
+		spec1 := baseSpec
+		spec2 := baseSpec
+
+		hash1, err1 := ComputeSpecHash(spec1)
+		hash2, err2 := ComputeSpecHash(spec2)
+
+		if err1 != nil || err2 != nil {
+			t.Fatalf("unexpected errors: err1=%v, err2=%v", err1, err2)
+		}
+		if hash1 != hash2 {
+			t.Errorf("expected hashes to match, got %s and %s", hash1, hash2)
+		}
+	})
+
+	t.Run("deterministic hash despite map key iteration order", func(t *testing.T) {
+		spec1 := DummySpec{
+			NodeSelector: map[string]string{"a": "1", "b": "2", "c": "3"},
+		}
+		spec2 := DummySpec{
+			NodeSelector: map[string]string{"c": "3", "a": "1", "b": "2"},
+		}
+
+		hash1, err1 := ComputeSpecHash(spec1)
+		hash2, err2 := ComputeSpecHash(spec2)
+
+		if err1 != nil || err2 != nil {
+			t.Fatalf("unexpected errors: err1=%v, err2=%v", err1, err2)
+		}
+		if hash1 != hash2 {
+			t.Errorf("expected identical hashes regardless of map construction order, got %s and %s", hash1, hash2)
+		}
+	})
+
+	t.Run("different spec fields produce different hashes", func(t *testing.T) {
+		modifiedSpec := baseSpec
+		modifiedSpec.VlanID = 200
+
+		hashBase, err1 := ComputeSpecHash(baseSpec)
+		hashMod, err2 := ComputeSpecHash(modifiedSpec)
+
+		if err1 != nil || err2 != nil {
+			t.Fatalf("unexpected errors: err1=%v, err2=%v", err1, err2)
+		}
+		if hashBase == hashMod {
+			t.Errorf("expected different hashes for different spec fields, but got same hash: %s", hashBase)
+		}
+	})
+}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

1. The HostNetworkConfig controller relied on storm-mode behavior to settle down as a single object represents cluster-level config and status.
2. If any node is flaky, the whole cluster will suffer. refer [Flaky node status updates trigger cluster-wide reconcile cascade and API server event storm in HostNetworkConfig controller](https://github.com/harvester/harvester/issues/11538)
3. The current interface exit shortcut (`checkifHostNetworkInterfaceExists`) does not cover failure scenarios such as IP setup failures. Refer [HostNetworkConfig marks a node ready without assigning the IP, and never retries](https://github.com/harvester/harvester/issues/11519)
4. Any detailed nework operation related errors ( set link, set up, set ip, dhcp request) are booked into CRD object status, which could cause API-server write pressure and controller event storm.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Use a local cache for fast-exit only when the target status is reached, avoiding unnecessary and heavy network-related operations, and also break the storm, the already-done cluster will go fast-exit.
2. For all other cases, execute the reconciliation loop from the beginning to ensure idempotency. If node does not reach the final status, do it step by step.
5. Refactor the function execution order during the teardown process.
6. Add helpers, utility functions, and unit tests to validate state caching and teardown behavior.
7. Summarize HNC setup errors to a high level error info to CRD status, and combine them with detailed return errors which are printed in POD log.

**Related Issue:**

https://github.com/harvester/harvester/issues/11538
https://github.com/harvester/harvester/issues/11519

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->


1. Test the IP change of HNC.  for issue https://github.com/harvester/harvester/issues/11618

<details>
<summary>test-1 details</summary>

This is also mentioned on: https://github.com/harvester/network-controller-harvester/pull/383 &  https://github.com/harvester/harvester/issues/11603

(1.1) Create any HNC with static IP e.g. `192.168.3.10` with vid 3 on mgmt, it creates link like `mgmt-br.3@mgmt-br`
(1.2) Change the HNC IP to 192.168.3.11, without this PR, the interface IP is not applied to node
with this PR, interface IP is changed instantly

```
79: mgmt-br.3@mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 52:54:00:c1:9d:05 brd ff:ff:ff:ff:ff:ff
    inet 192.168.3.11/24 brd 192.168.3.255 scope global mgmt-br.3
       valid_lft forever preferred_lft forever
```

(1.3) change the IP again
<img width="2334" height="1220" alt="image" src="https://github.com/user-attachments/assets/17db9601-7f9e-43c5-92cf-52dd7db680ff" />

```
79: mgmt-br.3@mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 52:54:00:c1:9d:05 brd ff:ff:ff:ff:ff:ff
    inet 192.168.3.12/24 brd 192.168.3.255 scope global mgmt-br.3
       valid_lft forever preferred_lft forever
```

network-controller-agent log:
```
time="2026-09-09T10:05:16Z" level=info msg="hostnetwork config hnc1 is changed, spec: {Description: NodeSelector:nil ClusterNetwork:mgmt Underlay:true VlanID:3 Mode:static HostIPs:map[harv31:192.168.3.11/24]}"
time="2026-09-09T10:05:16Z" level=info msg="link monitor nic has been changed, spec: {NodeSelector:map[] TargetLinkRule:{TypeRule:device NameRule:}}"
time="2026-09-09T10:05:16Z" level=info msg="cluster network mgmt will add 0 vlans, remove 0 vlans"
time="2026-09-09T10:05:16Z" level=info msg="cluster network mgmt has been changed, vid hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
time="2026-09-09T10:05:16Z" level=info msg="cluster network mgmt will add 0 vlans, remove 0 vlans"
time="2026-09-09T10:10:32Z" level=info msg="hostnetwork config hnc1 is changed, spec: {Description: NodeSelector:nil ClusterNetwork:mgmt Underlay:true VlanID:3 Mode:static HostIPs:map[harv31:192.168.3.12/24]}"
time="2026-09-09T10:10:32Z" level=info msg="cluster network mgmt has been changed, vid hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
time="2026-09-09T10:10:32Z" level=info msg="cluster network mgmt will add 0 vlans, remove 0 vlans"
time="2026-09-09T10:10:32Z" level=info msg="hostnetwork config hnc1 is changed, spec: {Description: NodeSelector:nil ClusterNetwork:mgmt Underlay:true VlanID:3 Mode:static HostIPs:map[harv31:192.168.3.12/24]}"
```
</details>

2. Test the IP mode change between DHCP and static. 

<details>
<summary>test-2 details</summary>

```
spec:
  clusterNetwork: mgmt
  ips:
    harv31: 192.168.4.10/24
  mode: static
  underlay: false
  vlanID: 4
status:
  nodeStatus:
    harv31:
      clusterNetwork: mgmt
      conditions:
      - message: ""
        status: "True"
        type: ready
      mode: static
      vlanID: 4
```

Note: HNC status is correctly updated, the the original static IP is not removed.

```
spec:
  clusterNetwork: mgmt
  mode: dhcp
  underlay: false
  vlanID: 4
status:
  nodeStatus:
    harv31:
      clusterNetwork: mgmt
      conditions:
      - message: 'setup l3 connectivity failed: unable to receive an offer: got an
          error while the discovery request: no matching response packet received'
        status: "False"
        type: ready
      mode: dhcp
      vlanID: 4


95: mgmt-br.4@mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 52:54:00:c1:9d:05 brd ff:ff:ff:ff:ff:ff
    inet 192.168.4.10/24 brd 192.168.4.255 scope global mgmt-br.4
       valid_lft forever preferred_lft forever
```

note: the static-ip leftover is booked via: https://github.com/harvester/harvester/issues/11617, it might be necessary to deny the `mode` change.

</details>

3. Test the abnormal like: manually put vlan sub-interface link down, retrigger the HNC via add an annotation, the HNC agent recover the agent;  this relies on the design: the local cache has TTL

<details>
<summary>test-3 details</summary>
</details>

4. Test the node-selector change: add new node

<details>
<summary>test-4 details</summary>
</details>

5. Test the node-selector change: remove one node

<details>
<summary>test-5 details</summary>
</details>

6. Test the summarized error info

<details>
<summary>test-6 details</summary>

```
arv31:/home/rancher # kubectl get hnc hnc -oyaml
apiVersion: network.harvesterhci.io/v1beta1
kind: HostNetworkConfig
metadata:
  creationTimestamp: "2026-09-09T10:14:54Z"
  finalizers:
  - wrangler.cattle.io/harvester-network-hostnetworkconfig-controller
  generation: 4
  name: hnc
  resourceVersion: "754520"
  uid: 2dc7333c-9b4e-4d9d-805d-4b7aa63d7ba1
spec:
  clusterNetwork: mgmt
  mode: dhcp
  underlay: false
  vlanID: 4
status:
  nodeStatus:
    harv31:
      clusterNetwork: mgmt
      conditions:
      - message: 'setup l3 connectivity failed: l3 address or dhcp allocation failed'
        status: "False"
        type: ready
      mode: dhcp
      vlanID: 4
      
time="2026-09-09T20:46:08Z" level=error msg="error syncing 'hnc': handler harvester-network-hostnetworkconfig-controller: setup host network config hnc failed [l3 address or dhcp allocation failed]: configErr: unable to receive an offer: got an error while the discovery request: no matching response packet received, requeuing"
time="2026-09-09T20:46:08Z" level=info msg="hostnetwork config hnc is changed, spec: {Description: NodeSelector:nil ClusterNetwork:mgmt Underlay:false VlanID:4 Mode:dhcp HostIPs:map[]}"
time="2026-09-09T20:46:08Z" level=info msg="cluster network mgmt has been changed, vid hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
time="2026-09-09T20:46:08Z" level=info msg="cluster network mgmt will add 0 vlans, remove 0 vlans"
time="2026-09-09T20:46:43Z" level=error msg="error syncing 'hnc': handler harvester-network-hostnetworkconfig-controller: setup host network config hnc failed [l3 address or dhcp allocation failed]: configErr: unable to receive an offer: got an error while the discovery request: no matching response packet received, requeuing"
time="2026-09-09T20:46:43Z" level=info msg="hostnetwork config hnc is changed, spec: {Description: NodeSelector:nil ClusterNetwork:mgmt Underlay:false VlanID:4 Mode:dhcp HostIPs:map[]}"
time="2026-09-09T20:46:44Z" level=info msg="cluster network mgmt has been changed, vid hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
time="2026-09-09T20:46:44Z" level=info msg="cluster network mgmt will add 0 vlans, remove 0 vlans"
time="2026-09-09T20:47:19Z" level=error msg="error syncing 'hnc': handler harvester-network-hostnetworkconfig-controller: setup host network config hnc failed [l3 address or dhcp allocation failed]: configErr: unable to receive an offer: got an error while the discovery request: no matching response packet received, requeuing"
time="2026-09-09T20:47:19Z" level=info msg="hostnetwork config hnc is changed, spec: {Description: NodeSelector:nil ClusterNetwork:mgmt Underlay:false VlanID:4 Mode:dhcp HostIPs:map[]}"
time="2026-09-09T20:47:19Z" level=info msg="cluster network mgmt has been changed, vid hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
time="2026-09-09T20:47:19Z" level=info msg="cluster network mgmt will add 0 vlans, remove 0 vlans"
time="2026-09-09T20:47:54Z" level=error msg="error syncing 'hnc': handler harvester-network-hostnetworkconfig-controller: setup host network config hnc failed [l3 address or dhcp allocation failed]: configErr: unable to receive an offer: got an error while the discovery request: no matching response packet received, requeuing"
time="2026-09-09T20:47:54Z" level=info msg="hostnetwork config hnc is changed, spec: {Description: NodeSelector:nil ClusterNetwork:mgmt Underlay:false VlanID:4 Mode:dhcp HostIPs:map[]}"
time="2026-09-09T20:47:54Z" level=info msg="cluster network mgmt has been changed, vid hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
time="2026-09-09T20:47:54Z" level=info msg="cluster network mgmt will add 0 vlans, remove 0 vlans"     
```

</details>
