### PR TITLE
[CI] Add validate check to avoid import harvester accidentally

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -3,6 +3,17 @@ set -e
 
 cd $(dirname $0)/..
 
+# WARNING: Do not import harvester/harvester to prevent circular dependencies
+# (harvester/harvester already depends on this repository).
+# If generated controllers or clients are needed, generate them locally instead.
+echo "Checking dependencies in go.mod"
+if grep -E 'github\.com/harvester/harvester([ /]|$)' go.mod; then
+    echo "Error: direct dependency on github.com/harvester/harvester is not allowed in go.mod" >&2
+    exit 1
+else
+    echo "PASS"
+fi
+
 if ! command -v golangci-lint; then
     echo Skipping validation: no golangci-lint available
     exit


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Harvester-network-controller ever looped importing harvester, and the loop dependency was decoupled before via PR https://github.com/harvester/network-controller-harvester/pull/217.

Now, there is a single direction dependency: harvester imports network-controller.

https://github.com/harvester/harvester/blob/8012209e56a610d73bfe453bf59283d496b5dcee/go.mod#L13

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This PR adds a check on `make validate` to ensure the depency is not added again accidentally.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Not required.

`make validate` runs smoothly